### PR TITLE
[codex] add opencode and pi providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 An **agent-agnostic implementation of Claude Code's Workflows**. omegacode runs JavaScript workflow
 files that orchestrate fleets of coding agents with a small deterministic DSL — `agent()` /
 `parallel()` / `pipeline()` / `phase()` — and the workers are pluggable: the same workflow can
-drive **Claude Code**, **Codex**, or both in a single run.
+drive **Claude Code**, **Codex**, **OpenCode**, **Pi**, or several providers in a single run.
 
 ## Install
 
@@ -20,8 +20,8 @@ omegacode install-skill
 `~/.claude/skills/` (Claude Code) and `~/.agents/skills/` (Codex and other agents). Pass
 `--claude` or `--agents` to install to just one.
 
-You'll need Node 20+ and at least one worker installed: `codex` (the default provider) and/or
-`claude`. Run `omegacode doctor` to check.
+You'll need Node 20+ and at least one worker installed: `codex` (the default provider),
+`claude`, `opencode`, or `pi`. Run `omegacode doctor` to check.
 
 ## Use it
 
@@ -52,8 +52,8 @@ return await pipeline(
 )
 ```
 
-Plain JavaScript, no imports — the DSL is injected. Each `agent()` spawns a real Codex or Claude
-Code agent; omit `provider` to inherit whatever the run was started with (`--provider`, default
+Plain JavaScript, no imports — the DSL is injected. Each `agent()` spawns a real provider-backed
+agent; omit `provider` to inherit whatever the run was started with (`--provider`, default
 `codex`), or pin it per call when you want cross-provider diversity.
 
 ## CLI
@@ -62,12 +62,18 @@ Code agent; omit `provider` to inherit whatever the run was started with (`--pro
 omegacode run <file.workflow.js | name>   # run a workflow (auto-starts the live viewer)
 omegacode serve                           # read-only dashboard over all runs
 omegacode run <name> --resume <runId>     # resume — only the changed suffix re-runs
-omegacode doctor                          # check codex/claude availability
+omegacode doctor                          # check provider availability
 omegacode guide                           # print the full authoring guide
 ```
 
+Providers are `codex`, `claude-code`, `opencode`, and `pi`. OpenCode models use
+`provider/model` names and currently require `danger-full-access` because omegacode cannot
+enforce OpenCode read-only mode itself. Pi runs in read-only mode with read/search tools only;
+`PI_PROVIDER` and `PI_MODEL` can provide its defaults, and `OPENCODE_BIN` / `PI_BIN` override
+binary paths.
+
 `run` also accepts saved workflow names. Six built-ins ship with the package:
-`deep-research`, `code-review`, and four multi-provider workflows that put the two
+`deep-research`, `code-review`, and four multi-provider workflows that put provider-diverse
 models' decorrelated errors to work — `multi-provider-review` (both review the same
 branch independently, then a synthesis merges both), `bake-off` (both implement the
 same task in isolated worktrees, blind cross-provider judges pick a winner),

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: omegacode
-description: Author and run multi-agent workflows with the `omegacode` CLI — JavaScript files that orchestrate Codex (gpt-5.x) and Claude Code agents deterministically via agent()/parallel()/pipeline()/phase(). Use when a task is big enough to decompose and run in parallel, when you want independent perspectives and adversarial checks before committing, or when the work is too large for one context (broad audits, migrations, multi-source research, exhaustive reviews). Covers the file shape, the DSL, mixing providers, structured output, worktree isolation, determinism, resume, the live viewer, and every CLI command.
+description: Author and run multi-agent workflows with the `omegacode` CLI — JavaScript files that orchestrate Codex (gpt-5.x), Claude Code, OpenCode, and Pi agents deterministically via agent()/parallel()/pipeline()/phase(). Use when a task is big enough to decompose and run in parallel, when you want independent perspectives and adversarial checks before committing, or when the work is too large for one context (broad audits, migrations, multi-source research, exhaustive reviews). Covers the file shape, the DSL, mixing providers, structured output, worktree isolation, determinism, resume, the live viewer, and every CLI command.
 metadata:
   type: reference
 ---
 
 # omegacode
 
-Run a workflow file that orchestrates multiple agents deterministically. `omegacode run <file.workflow.js>` executes the file; it persists to `~/.omegacode/runs/<id>/` and prints a runId. Use `omegacode serve` (or `run --open`) to watch live progress. Each `agent()` call spawns a real **Codex** (gpt-5.x) or **Claude Code** agent — you pick the provider per call.
+Run a workflow file that orchestrates multiple agents deterministically. `omegacode run <file.workflow.js>` executes the file; it persists to `~/.omegacode/runs/<id>/` and prints a runId. Use `omegacode serve` (or `run --open`) to watch live progress. Each `agent()` call spawns a real **Codex** (gpt-5.x), **Claude Code**, **OpenCode**, or **Pi** agent — you pick the provider per call.
 
 A workflow structures work across many agents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before committing), or to take on scale one context can't hold (migrations, audits, broad sweeps). The file is where you encode that structure: what fans out, what verifies, what synthesizes.
 
@@ -41,7 +41,7 @@ const flaky = await agent('grep CI logs for retry markers', { schema: FLAKY_SCHE
 The `meta` object must be a PURE LITERAL — no variables, function calls, spreads, or template interpolation. Required fields: `name`, `description`. Optional: `phases`. Use the SAME phase titles in meta.phases as in phase() calls — titles are matched exactly; a phase() call with no matching meta entry just gets its own progress group.
 
 Script body hooks:
-- agent(prompt: string, opts?: {provider?: 'codex' | 'claude-code', model?: string, effort?: string, schema?: object, label?: string, sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access', cwd?: string, instructions?: string, maxTurns?: number, worktree?: boolean, key?: string}): Promise<any> — spawn an agent. Without schema, returns its final text as a string. With schema (a JSON Schema), the agent is forced to return JSON matching it and agent() returns the validated object — no parsing needed. Returns null if the user skips the agent mid-run (filter with .filter(Boolean)). opts.provider / opts.model: **default to omitting both** — the agent inherits the provider and model the workflow is being run with (set by `--provider`/`--model`, default `codex`), which is almost always correct. Only set them when the user explicitly asks for a specific provider/model, or you're highly confident a particular step needs a different one. opts.label overrides the display label. opts.sandbox defaults to `read-only`; use `workspace-write` (write to cwd + network) only when the agent must write. opts.worktree: true runs the agent in a fresh git worktree — EXPENSIVE (setup + disk per agent), use ONLY when agents mutate files in parallel and would otherwise conflict; the worktree is auto-removed if unchanged. opts.key is a stable resume pin that survives prompt-wording/reordering edits.
+- agent(prompt: string, opts?: {provider?: 'codex' | 'claude-code' | 'opencode' | 'pi', model?: string, effort?: string, schema?: object, label?: string, sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access', cwd?: string, instructions?: string, maxTurns?: number, worktree?: boolean, key?: string}): Promise<any> — spawn an agent. Without schema, returns its final text as a string. With schema (a JSON Schema), the agent is forced to return JSON matching it and agent() returns the validated object — no parsing needed. Returns null if the user skips the agent mid-run (filter with .filter(Boolean)). opts.provider / opts.model: **default to omitting both** — the agent inherits the provider and model the workflow is being run with (set by `--provider`/`--model`, default `codex`), which is almost always correct. Only set them when the user explicitly asks for a specific provider/model, or you're highly confident a particular step needs a different one. opts.label overrides the display label. opts.sandbox defaults to `read-only`; use `workspace-write` (write to cwd + network) only when the agent must write. opts.worktree: true runs the agent in a fresh git worktree — EXPENSIVE (setup + disk per agent), use ONLY when agents mutate files in parallel and would otherwise conflict; the worktree is auto-removed if unchanged. opts.key is a stable resume pin that survives prompt-wording/reordering edits.
 - pipeline(items, stage1, stage2, ...): Promise<any[]> — run each item through all stages independently, NO barrier between stages. Item A can be in stage 3 while item B is still in stage 1. This is the DEFAULT for multi-stage work. Wall-clock = slowest single-item chain, not sum-of-slowest-per-stage. Every stage callback receives (prevResult, originalItem, index) — use originalItem/index in later stages to label work without threading context through stage 1's return value. A stage that throws drops that item to `null` and skips its remaining stages.
 - parallel(thunks: Array<() => Promise<any>>): Promise<any[]> — run tasks concurrently. This is a BARRIER: awaits all thunks before returning. A thunk that throws (or whose agent errors) resolves to `null` in the result array — the call itself never rejects, so `.filter(Boolean)` before using the results. Use ONLY when you genuinely need all results together.
 - log(message: string): void — emit a progress message to the user (shown as a narrator line above the progress tree)
@@ -52,17 +52,19 @@ Script body hooks:
 
 Agents are told their final text IS the return value (not a human-facing message), so they return raw data. For structured output, use the schema option — validation happens at the worker layer and the agent retries once on a mismatch.
 
-## Providers — codex vs claude-code
+## Providers
 
 Every agent() runs under a provider/model. **By default, do NOT set `provider` or `model` per agent** — each agent inherits the provider/model the workflow is being run with (`--provider` / `--model`, default `codex`), which is almost always what you want. Most workflows (including the canonical example and the patterns above) omit them entirely. Pin them only when the user explicitly asks for a specific provider/model, or you're confident a particular step needs a different one. `omegacode doctor` shows which providers are installed/authed.
 
-The two providers:
+Providers:
 - **codex** (OpenAI, gpt-5.x) — the default. `opts.effort` tunes reasoning depth: `"minimal" | "low" | "medium" | "high" | "xhigh"`. Requires the `codex` CLI authenticated (ChatGPT login); its built-in tools (incl. hosted image generation) come from that auth, and it ignores `OPENAI_API_KEY`. Native structured output via a free-form working turn then a schema-constrained extraction turn.
 - **claude-code** (Anthropic) — via the Claude Agent SDK; requires the `claude` CLI / SDK available. `opts.effort` accepts `"low" | "medium" | "high" | "xhigh" | "max"` (`max` is Opus-tier; the model silently downgrades unsupported levels). Structured output is delivered on the final result only (intermediate messages stay free-form).
+- **opencode** — via `opencode run --format json`; requires the `opencode` CLI. `opts.model` must use OpenCode's `provider/model` form, so omegacode can pass through any model OpenCode supports. OpenCode is currently limited to `danger-full-access` in omegacode because its CLI does not expose a read-only mode omegacode can enforce.
+- **pi** — via `pi --mode json --print`; requires the `pi` CLI. `opts.model` is passed through to Pi, and `PI_PROVIDER` / `PI_MODEL` can set provider defaults for Pi runs. Pi is limited to read-only operation in omegacode with `read,grep,find,ls` tools and explicit workspace-root instructions.
 
-(`opts.effort` is a single union — `"minimal" | "low" | "medium" | "high" | "xhigh" | "max"` — and each worker maps to its nearest supported level: `minimal`→`low` on claude, `max`→`xhigh` on codex.)
+(`opts.effort` is a single union — `"none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"` — and each worker maps to its nearest supported level: `minimal`→`low` on claude, `none`→`off` on Pi, `max`→`xhigh` on codex/Pi.)
 
-Both honor `sandbox` (read-only by default) and `cwd`; `worktree: true` isolates parallel file edits regardless of provider.
+Codex and Claude Code honor `sandbox` (read-only by default) and `cwd`; Pi only supports `read-only`; OpenCode only supports `danger-full-access` until omegacode can enforce a read-only OpenCode mode. `worktree: true` isolates parallel file edits regardless of provider.
 
 The default case — omit provider, so fan-out and synthesis run on whatever provider the workflow was invoked with:
 ```js
@@ -200,7 +202,7 @@ Every run has a runId (printed on completion). To resume after a script edit or 
 
 ```
 omegacode run <file.workflow.js | name> [--args '<json>' | --args-file <f>]
-                                       [--provider codex|claude-code] [--model m] [--effort e]
+                                       [--provider codex|claude-code|opencode|pi] [--model m] [--effort e]
                                        [--sandbox read-only|workspace-write|danger-full-access] [--cwd dir]
                                        [--concurrency N] [--budget N] [--resume <runId>] [--fake] [--json] [--open]
 omegacode serve [--port 4123] [--host h]      Live read-only web viewer of all runs
@@ -208,7 +210,7 @@ omegacode runs [--prune --keep <N>]           List runs (or prune old ones)
 omegacode workflows [--json]                  List saved/named workflows (project, user, builtin)
 omegacode save <file.workflow.js> [--project] [--force]   Save a workflow under its meta.name
 omegacode validate <file.workflow.js | name>  Parse + check meta without running
-omegacode doctor                              Check codex/claude availability + data dir
+omegacode doctor                              Check provider availability + data dir
 omegacode install-skill [--claude] [--agents] Install this skill into agent skill dirs
 ```
 
@@ -222,7 +224,7 @@ Six built-ins ship with the package. Two are ports of Claude Code's bundled work
 - **`deep-research`** — `omegacode run deep-research --args '"<question>"'`: scope → 5 parallel web searches → fetch/dedup top sources → 3-vote adversarial verification per claim → cited report.
 - **`code-review`** — `omegacode run code-review [--args '{"target": "...", "level": "high|xhigh|max"}']`: one finder per review angle, an independent verifier per finding (CONFIRMED/PLAUSIBLE/REFUTED), a gap-sweep at xhigh/max, ranked report.
 
-The other four are omegacode-original multi-provider workflows — designs where two models' decorrelated errors are the point:
+The other four are omegacode-original multi-provider workflows — designs where provider-diverse models' decorrelated errors are the point:
 - **`multi-provider-review`** — `omegacode run multi-provider-review [--args '{"target": "..."}']`: Codex and Claude each review the entire feature/branch independently (identical prompts, blind to each other), then a synthesis agent merges both — consensus findings ranked first, unique catches attributed, disagreements called out. Target defaults to the current branch vs its merge-base with the default branch.
 - **`bake-off`** — `omegacode run bake-off --args '"<task>"'`: both providers implement the same task in isolated worktrees (committed work only), blind A/B judges from both providers score the diffs, a tie-break settles splits, and the report names what to graft from the loser. Both branches are preserved.
 - **`provider-debate`** — `omegacode run provider-debate --args '"<question>"'` (or `'{"question": "...", "rounds": 2, "proposer": "codex"}'`): one provider proposes, the other attacks, N rounds of rebuttal, then a judge rules — recommendation, survived/conceded points, open questions.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,7 +131,7 @@ function numberFlag(flags: Flags, name: string): number | undefined {
   return n
 }
 
-const PROVIDERS: ProviderId[] = ["codex", "claude-code"]
+const PROVIDERS: ProviderId[] = ["codex", "claude-code", "opencode", "pi"]
 const SANDBOXES: Sandbox[] = ["read-only", "workspace-write", "danger-full-access"]
 const EFFORTS: Effort[] = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
 
@@ -378,7 +378,7 @@ function dirSize(dir: string): number {
 async function cmdRun(flags: Flags): Promise<void> {
   const file = (flags._ as string[])[1]
   if (!file) {
-    console.error("usage: omegacode run <file.workflow.js | name> [--args <json>] [--provider codex|claude-code] [--fake] [--json]")
+    console.error("usage: omegacode run <file.workflow.js | name> [--args <json>] [--provider codex|claude-code|opencode|pi] [--fake] [--json]")
     process.exitCode = 1
     return
   }
@@ -553,8 +553,10 @@ async function cmdDoctor(): Promise<void> {
   }
   console.log("omegacode doctor")
   console.log(`  fake worker  : ok`)
-  console.log(`  codex        : ${check("codex", ["--version"])}`)
+  console.log(`  codex        : ${check(process.env.CODEX_BIN ?? "codex", ["--version"])}`)
   console.log(`  claude-code  : ${check("claude", ["--version"])}`)
+  console.log(`  opencode     : ${check(process.env.OPENCODE_BIN ?? "opencode", ["--version"])}`)
+  console.log(`  pi           : ${check(process.env.PI_BIN ?? "pi", ["--version"])}`)
   console.log(`  data dir     : ${dataRoot()}`)
 }
 
@@ -598,16 +600,17 @@ async function cmdInstallSkill(flags: Flags): Promise<void> {
 }
 
 function printHelp(): void {
-  console.log(`omegacode — run JS workflow files that orchestrate Codex and Claude Code agents
+  console.log(`omegacode — run JS workflow files that orchestrate multiple agent providers
 
 A workflow is a .js file: \`export const meta = {...}\` then a body using the injected
 DSL — agent() / parallel() / pipeline() / phase() / log() / now() / random() / budget / args.
-Each agent() spawns a real Codex (gpt-5.x) or Claude Code agent; you pick the provider per call.
+Each agent() spawns a real provider-backed agent; you pick the provider per call.
 
 Usage:
   omegacode run <file.workflow.js | name> [options]   Run a workflow (by path or saved name)
       --args '<json>' | --args-file <f>    input exposed as the \`args\` global
-      --provider codex|claude-code         default provider (per-agent opts override)
+      --provider codex|claude-code|opencode|pi
+                                            default provider (per-agent opts override)
       --model <m>  --effort <e>  --sandbox read-only|workspace-write|danger-full-access
       --cwd <dir>  --concurrency <N>       working dir; max concurrent agents (default ${DEFAULTS.concurrency})
       --budget <N>                         output-token ceiling (enables budget.*)
@@ -620,12 +623,16 @@ Usage:
   By default \`run\` auto-starts the viewer (if not already up) and prints the run's URL
   (with --json the URL is in the JSON \`url\` field and the \`view:\` line is suppressed).
 
+Provider environment:
+  CODEX_BIN, OPENCODE_BIN, PI_BIN        override provider executable paths
+  PI_PROVIDER, PI_MODEL                  defaults for pi when not set per agent
+
   omegacode serve [--port 4123] [--host h] [--idle-shutdown]   Live read-only web viewer of all runs
   omegacode runs [--prune --keep <N>] [--prune-stale]   List runs (--prune old, --prune-stale dead)
   omegacode workflows [--json]                  List saved/named workflows (project, user, builtin)
   omegacode save <file.workflow.js> [--project] [--force]   Save a workflow under its meta.name
   omegacode validate <file.workflow.js | name>  Parse + check meta without running
-  omegacode doctor                              Check codex/claude availability + data dir
+  omegacode doctor                              Check provider availability + data dir
   omegacode guide                               Print the full authoring guide (the skill text)
   omegacode install-skill [--claude] [--agents] Install the authoring skill into agent skill dirs
 

--- a/src/dsl/ambient.d.ts
+++ b/src/dsl/ambient.d.ts
@@ -7,7 +7,7 @@
 // of the ones in ./types.ts; keep them in sync (a packaging test asserts the union members).
 
 declare global {
-  type OmegacodeProviderId = "codex" | "claude-code"
+  type OmegacodeProviderId = "codex" | "claude-code" | "opencode" | "pi"
 
   type OmegacodeSandbox = "read-only" | "workspace-write" | "danger-full-access"
 
@@ -42,7 +42,7 @@ declare global {
     index: number,
   ) => unknown | Promise<unknown>
 
-  /** Run one agent turn (Codex or Claude Code, per opts.provider). Returns final text, or a
+  /** Run one agent turn (per opts.provider). Returns final text, or a
    *  validated object when opts.schema is set. */
   function agent<T = string>(prompt: string, opts?: OmegacodeAgentOpts): Promise<T>
 

--- a/src/dsl/types.ts
+++ b/src/dsl/types.ts
@@ -1,12 +1,11 @@
 // Shared type contracts for the whole system. Everything compiles against these.
 
-export type ProviderId = "codex" | "claude-code"
+export type ProviderId = "codex" | "claude-code" | "opencode" | "pi"
 
 /** read-only: no writes; workspace-write: write within cwd; danger-full-access: unrestricted. */
 export type Sandbox = "read-only" | "workspace-write" | "danger-full-access"
 
-// Union of both providers' reasoning-effort levels. codex: none/minimal/low/medium/high/xhigh;
-// claude-code: low/medium/high/xhigh/max. Each worker maps to its nearest supported value.
+// Union of supported providers' reasoning-effort levels. Each worker maps to its nearest supported value.
 export type Effort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
 
 export type Approval = "never" | "on-request"

--- a/src/runtime/primitives.ts
+++ b/src/runtime/primitives.ts
@@ -41,6 +41,7 @@ export class AgentFailedError extends WorkflowError {}
 
 /** Valid values for the enum-typed spec fields, validated at spec resolution (H14). */
 export const SPEC_ENUMS = {
+  provider: ["codex", "claude-code", "opencode", "pi"],
   sandbox: ["read-only", "workspace-write", "danger-full-access"],
   effort: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
   approval: ["never", "on-request"],
@@ -221,6 +222,7 @@ export class Runtime {
       maxTurns: opts?.maxTurns,
     }
     // Validate the RESOLVED values so both per-call opts and run defaults are covered (H14).
+    checkSpecEnum("provider", spec.provider)
     checkSpecEnum("sandbox", spec.sandbox)
     checkSpecEnum("effort", spec.effort)
     checkSpecEnum("approval", spec.approval)

--- a/src/runtime/run.ts
+++ b/src/runtime/run.ts
@@ -31,6 +31,10 @@ export interface RunOverrides {
   cwd?: string
   concurrency?: number
   budget?: number | null
+  opencodeBin?: string
+  piBin?: string
+  piProvider?: string
+  piModel?: string
   /** Forwarded to the Claude worker when provider === "claude-code". */
   claudeModel?: string
   /** Path to the claude-code executable (forwarded to the Claude worker). */
@@ -108,6 +112,10 @@ export async function runWorkflow(opts: RunOptions): Promise<RunOutcome> {
   const factory = new DefaultWorkerFactory({
     fake: opts.fake,
     codexBin: process.env.CODEX_BIN,
+    opencodeBin: opts.overrides?.opencodeBin ?? process.env.OPENCODE_BIN,
+    piBin: opts.overrides?.piBin ?? process.env.PI_BIN,
+    piProvider: opts.overrides?.piProvider ?? process.env.PI_PROVIDER,
+    piModel: opts.overrides?.piModel ?? (defaults.provider === "pi" ? defaults.model : undefined) ?? process.env.PI_MODEL,
     // Claude-specific factory defaults (L5). Only forwarded when the provider is claude-code; a
     // per-call opts.model still overrides via AgentSpec.model.
     claudeModel: opts.overrides?.claudeModel ?? (defaults.provider === "claude-code" ? defaults.model : undefined),
@@ -189,11 +197,13 @@ function resolveDefaults(meta: { defaultProvider?: ProviderId; defaultModel?: st
   // unvalidated into every spec and fall off the worker policy switches (H14) — e.g. "readonly"
   // (typo for "read-only") becomes effectively writable. Fail here, like concurrency above.
   // resolveSpec re-checks the resolved per-call values, covering workflow-body opts too.
+  const provider = o.provider ?? meta.defaultProvider ?? DEFAULTS.provider
+  checkSpecEnum("provider", provider)
   const sandbox = o.sandbox ?? meta.defaultSandbox ?? DEFAULTS.sandbox
   checkSpecEnum("sandbox", sandbox)
   checkSpecEnum("effort", o.effort)
   return {
-    provider: o.provider ?? meta.defaultProvider ?? DEFAULTS.provider,
+    provider,
     model: o.model ?? meta.defaultModel,
     effort: o.effort,
     sandbox,

--- a/src/worker/factory.ts
+++ b/src/worker/factory.ts
@@ -3,11 +3,17 @@ import { AgentError, type Worker, type WorkerFactory } from "./index.js"
 import { FakeWorker } from "./fake.js"
 import { CodexWorker } from "./codex.js"
 import { ClaudeWorker } from "./claude.js"
+import { OpenCodeWorker } from "./opencode.js"
+import { PiWorker } from "./pi.js"
 
 export interface FactoryOpts {
   /** Use the in-process FakeWorker for every provider (smoke tests, --fake). */
   fake?: boolean
   codexBin?: string
+  opencodeBin?: string
+  piBin?: string
+  piProvider?: string
+  piModel?: string
   claudeModel?: string
   /** Path to the claude-code executable (forwarded to the SDK). */
   pathToClaudeCodeExecutable?: string
@@ -36,6 +42,10 @@ export class DefaultWorkerFactory implements WorkerFactory {
           model: this.opts.claudeModel,
           pathToClaudeCodeExecutable: this.opts.pathToClaudeCodeExecutable,
         })
+      case "opencode":
+        return new OpenCodeWorker({ bin: this.opts.opencodeBin })
+      case "pi":
+        return new PiWorker({ bin: this.opts.piBin, provider: this.opts.piProvider, model: this.opts.piModel })
       default: {
         // Exhaustive: a new ProviderId must be handled here, and an unknown runtime value
         // must fail loudly instead of silently routing to a billed provider.

--- a/src/worker/opencode.ts
+++ b/src/worker/opencode.ts
@@ -1,0 +1,49 @@
+import type { AgentResult, AgentSpec, Effort } from "../dsl/types.js"
+import type { Worker, WorkerContext } from "./index.js"
+import { AgentError } from "./index.js"
+import { SubprocessJsonlWorker, type SubprocessSpawn } from "./subprocess-jsonl.js"
+
+export interface OpenCodeWorkerOpts {
+  bin?: string
+  spawnChild?: SubprocessSpawn
+}
+
+export class OpenCodeWorker implements Worker {
+  readonly id = "opencode" as const
+  private readonly inner: SubprocessJsonlWorker
+
+  constructor(private readonly opts: OpenCodeWorkerOpts = {}) {
+    this.inner = new SubprocessJsonlWorker({
+      provider: this.id,
+      spawnChild: opts.spawnChild,
+      buildTurn: (spec, prompt) => {
+        if (spec.model && !spec.model.includes("/")) {
+          throw new AgentError({
+            provider: this.id,
+            code: "invalid_model",
+            message: 'opencode models must be in "provider/model" form, for example "anthropic/claude-sonnet-4"',
+          })
+        }
+        const args = ["run", "--format", "json", "--dir", spec.cwd]
+        if (spec.model) args.push("--model", spec.model)
+        args.push("--dangerously-skip-permissions")
+        const variant = toOpenCodeVariant(spec.effort)
+        if (variant) args.push("--variant", variant)
+        const stdin = spec.instructions ? `Instructions:\n${spec.instructions}\n\nPrompt:\n${prompt}` : prompt
+        return { command: opts.bin ?? "opencode", args, cwd: spec.cwd, stdin }
+      },
+    })
+  }
+
+  runAgent(spec: AgentSpec, ctx: WorkerContext): Promise<AgentResult> {
+    return this.inner.runSubprocessAgent(spec, ctx)
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner.shutdown()
+  }
+}
+
+function toOpenCodeVariant(effort: Effort | undefined): string | undefined {
+  return effort
+}

--- a/src/worker/pi.ts
+++ b/src/worker/pi.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { AgentResult, AgentSpec, Effort } from "../dsl/types.js"
+import type { Worker, WorkerContext } from "./index.js"
+import { SubprocessJsonlWorker, type SubprocessSpawn } from "./subprocess-jsonl.js"
+
+export interface PiWorkerOpts {
+  bin?: string
+  provider?: string
+  model?: string
+  spawnChild?: SubprocessSpawn
+}
+
+export class PiWorker implements Worker {
+  readonly id = "pi" as const
+  private readonly inner: SubprocessJsonlWorker
+
+  constructor(private readonly opts: PiWorkerOpts = {}) {
+    this.inner = new SubprocessJsonlWorker({
+      provider: this.id,
+      spawnChild: opts.spawnChild,
+      allowedSandboxes: ["read-only"],
+      buildTurn: (spec, prompt) => {
+        const stateDir = mkdtempSync(join(tmpdir(), "omegacode-pi-"))
+        const sessionDir = join(stateDir, "sessions")
+        const agentDir = join(stateDir, "agent")
+        const args = ["--mode", "json", "--print", "--no-session", "--no-approve", "--session-dir", sessionDir, "--tools", "read,grep,find,ls"]
+        const provider = opts.provider
+        const model = spec.model ?? opts.model
+        if (provider) args.push("--provider", provider)
+        if (model) args.push("--model", model)
+        const thinking = toPiThinking(spec.effort)
+        if (thinking) args.push("--thinking", thinking)
+        const workspaceInstructions = [
+          `Target workspace root: ${spec.cwd}`,
+          "Treat the target workspace as read-only.",
+          "Use absolute paths under the target workspace for read, grep, find, and ls tool calls.",
+        ].join("\n")
+        args.push("--append-system-prompt", spec.instructions ? `${workspaceInstructions}\n\n${spec.instructions}` : workspaceInstructions)
+        return {
+          command: opts.bin ?? "pi",
+          args,
+          cwd: stateDir,
+          stdin: prompt,
+          env: {
+            ...process.env,
+            PI_CODING_AGENT_DIR: agentDir,
+            PI_CODING_AGENT_SESSION_DIR: sessionDir,
+          },
+          cleanup: () => rmSync(stateDir, { recursive: true, force: true }),
+        }
+      },
+    })
+  }
+
+  runAgent(spec: AgentSpec, ctx: WorkerContext): Promise<AgentResult> {
+    return this.inner.runSubprocessAgent(spec, ctx)
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner.shutdown()
+  }
+}
+
+function toPiThinking(effort: Effort | undefined): string | undefined {
+  if (!effort) return undefined
+  if (effort === "none") return "off"
+  if (effort === "max") return "xhigh"
+  return effort
+}

--- a/src/worker/subprocess-jsonl.ts
+++ b/src/worker/subprocess-jsonl.ts
@@ -1,0 +1,415 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from "node:child_process"
+import { addUsage, emptyUsage, type AgentResult, type AgentSpec, type AgentUsage, type ProviderId, type Sandbox } from "../dsl/types.js"
+import { AgentError, AgentInterrupted, type WorkerContext, type WorkerProgress } from "./index.js"
+import { assertValidSchema, parseJsonLoose, stripNullOptionals, validate } from "./schema.js"
+
+export type SubprocessSpawn = (
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+) => ChildProcessWithoutNullStreams
+
+export interface SubprocessTurn {
+  command: string
+  args: string[]
+  cwd: string
+  stdin?: string
+  env?: NodeJS.ProcessEnv
+  cleanup?: () => void
+}
+
+export interface SubprocessJsonlWorkerOpts {
+  provider: ProviderId
+  buildTurn: (spec: AgentSpec, prompt: string) => SubprocessTurn
+  spawnChild?: SubprocessSpawn
+  allowedSandboxes?: readonly Sandbox[]
+}
+
+const STDERR_LIMIT = 16 * 1024
+
+const EXTRACTION_PROMPT = (text: string, schema: unknown): string =>
+  [
+    "Convert the assistant output below into a single JSON value that conforms to this JSON Schema.",
+    "Output only JSON. Do not include prose or code fences.",
+    "",
+    "JSON Schema:",
+    JSON.stringify(schema),
+    "",
+    "Assistant output:",
+    text,
+  ].join("\n")
+
+export class SubprocessJsonlWorker {
+  private readonly provider: ProviderId
+  private readonly buildTurn: (spec: AgentSpec, prompt: string) => SubprocessTurn
+  private readonly spawnChild: SubprocessSpawn
+  private readonly allowedSandboxes: readonly Sandbox[]
+  private readonly children = new Set<ChildProcessWithoutNullStreams>()
+  private readonly childCleanups = new Map<ChildProcessWithoutNullStreams, () => void>()
+
+  constructor(opts: SubprocessJsonlWorkerOpts) {
+    this.provider = opts.provider
+    this.buildTurn = opts.buildTurn
+    this.spawnChild = opts.spawnChild ?? ((command, args, options) => spawn(command, args, options) as ChildProcessWithoutNullStreams)
+    this.allowedSandboxes = opts.allowedSandboxes ?? ["danger-full-access"]
+  }
+
+  async runSubprocessAgent(spec: AgentSpec, ctx: WorkerContext): Promise<AgentResult> {
+    this.validateCommonOptions(spec)
+    if (spec.schema) {
+      try {
+        assertValidSchema(spec.schema)
+      } catch (err) {
+        throw new AgentError({ provider: this.provider, code: "invalid_schema", message: `output schema does not compile: ${(err as Error).message}` })
+      }
+    }
+
+    const working = await this.runTurn(spec, spec.prompt, ctx, true)
+    if (!spec.schema) return working
+
+    const extraction = await this.runTurn(spec, EXTRACTION_PROMPT(working.text, spec.schema), ctx, false)
+    let structured: unknown
+    try {
+      structured = stripNullOptionals(parseJsonLoose(extraction.text), spec.schema)
+    } catch (err) {
+      throw new AgentError({ provider: this.provider, code: "invalid_structured_output", message: `structured output was not valid JSON: ${(err as Error).message}`, usage: addUsage(working.usage, extraction.usage) })
+    }
+    const verdict = validate(spec.schema, structured)
+    if (!verdict.ok) {
+      throw new AgentError({ provider: this.provider, code: "invalid_structured_output", message: `structured output did not match schema: ${verdict.errors}`, usage: addUsage(working.usage, extraction.usage) })
+    }
+    return {
+      text: extraction.text,
+      structured,
+      status: "completed",
+      usage: addUsage(working.usage, extraction.usage),
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    for (const child of this.children) {
+      try {
+        child.kill()
+      } catch {
+        // best-effort
+      }
+      this.cleanupTurn(child)
+    }
+    this.children.clear()
+  }
+
+  private validateCommonOptions(spec: AgentSpec): void {
+    if (spec.maxTurns !== undefined) {
+      throw new AgentError({
+        provider: this.provider,
+        code: "unsupported_option",
+        message: `${this.provider} does not support maxTurns; omit maxTurns for this provider`,
+      })
+    }
+    if (spec.approval !== "never") {
+      throw new AgentError({
+        provider: this.provider,
+        code: "unsupported_option",
+        message: `${this.provider} only supports approval "never"; approval "${spec.approval}" is not supported`,
+      })
+    }
+    if (!this.allowedSandboxes.includes(spec.sandbox)) {
+      throw new AgentError({
+        provider: this.provider,
+        code: "unsupported_option",
+        message: `${this.provider} cannot enforce sandbox "${spec.sandbox}" in subprocess mode; supported sandbox values for this provider: ${this.allowedSandboxes.join(", ")}`,
+      })
+    }
+  }
+
+  private runTurn(spec: AgentSpec, prompt: string, ctx: WorkerContext, forwardProgress: boolean): Promise<AgentResult> {
+    if (ctx.signal.aborted) return Promise.reject(new AgentInterrupted())
+    const turn = this.buildTurn(spec, prompt)
+
+    return new Promise<AgentResult>((resolve, reject) => {
+      let child: ChildProcessWithoutNullStreams
+      try {
+        child = this.spawnChild(turn.command, turn.args, {
+          cwd: turn.cwd,
+          env: turn.env,
+          stdio: (turn.stdin === undefined ? ["ignore", "pipe", "pipe"] : ["pipe", "pipe", "pipe"]) as SpawnOptions["stdio"],
+        })
+      } catch (err) {
+        runCleanup(turn.cleanup)
+        reject(processSpawnError(this.provider, turn.command, err))
+        return
+      }
+
+      this.children.add(child)
+      if (turn.cleanup) this.childCleanups.set(child, turn.cleanup)
+      child.stdout.setEncoding("utf8")
+      child.stderr.setEncoding("utf8")
+      let stdoutBuf = ""
+      let rawStdout = ""
+      let text = ""
+      let usage = emptyUsage()
+      let stderr = ""
+      let settled = false
+      let killTimer: ReturnType<typeof setTimeout> | undefined
+
+      const cleanupChild = (): void => {
+        this.children.delete(child)
+        this.cleanupTurn(child)
+        if (killTimer) {
+          clearTimeout(killTimer)
+          killTimer = undefined
+        }
+      }
+
+      const terminateChild = (): void => {
+        try {
+          child.kill()
+        } catch {
+          // best-effort
+        }
+        killTimer ??= setTimeout(() => {
+          try {
+            child.kill("SIGKILL")
+          } catch {
+            // best-effort
+          }
+        }, 5000)
+        killTimer.unref?.()
+      }
+
+      const settle = (fn: () => void, opts: { keepChild?: boolean } = {}): void => {
+        if (settled) return
+        settled = true
+        if (!opts.keepChild) cleanupChild()
+        ctx.signal.removeEventListener("abort", onAbort)
+        fn()
+      }
+
+      const onAbort = (): void => {
+        terminateChild()
+        settle(() => reject(new AgentInterrupted()), { keepChild: true })
+      }
+
+      ctx.signal.addEventListener("abort", onAbort, { once: true })
+      if (turn.stdin !== undefined) {
+        try {
+          child.stdin.end(turn.stdin)
+        } catch (err) {
+          terminateChild()
+          settle(() => reject(new AgentError({ provider: this.provider, code: "stdin_write_failed", message: `failed to write stdin for ${turn.command}: ${(err as Error).message}`, retryable: true })), { keepChild: true })
+          return
+        }
+      }
+      child.stdout.on("data", (chunk: string) => {
+        if (settled) return
+        rawStdout += chunk
+        stdoutBuf += chunk
+        let nl = stdoutBuf.indexOf("\n")
+        while (nl !== -1) {
+          const line = stdoutBuf.slice(0, nl)
+          stdoutBuf = stdoutBuf.slice(nl + 1)
+          let folded: { text: string; usage: AgentUsage }
+          try {
+            folded = this.consumeLine(line, ctx, forwardProgress)
+          } catch (err) {
+            terminateChild()
+            settle(() => reject(err instanceof Error ? err : new Error(String(err))), { keepChild: true })
+            return
+          }
+          text += folded.text
+          usage = addUsage(usage, folded.usage)
+          nl = stdoutBuf.indexOf("\n")
+        }
+      })
+      child.stderr.on("data", (chunk: string) => {
+        stderr = (stderr + chunk).slice(-STDERR_LIMIT)
+      })
+      child.on("error", (err) => {
+        settle(() => reject(processRuntimeError(this.provider, turn.command, err)))
+      })
+      if (turn.stdin !== undefined) {
+        child.stdin.on("error", (err) => {
+          if (settled) return
+          terminateChild()
+          settle(() => reject(new AgentError({ provider: this.provider, code: "stdin_write_failed", message: `failed to write stdin for ${turn.command}: ${err.message}`, retryable: true })), { keepChild: true })
+        })
+      }
+      child.on("exit", (code, signal) => {
+        cleanupChild()
+        if (settled) return
+        if (stdoutBuf.trim()) {
+          let folded: { text: string; usage: AgentUsage }
+          try {
+            folded = this.consumeLine(stdoutBuf, ctx, forwardProgress)
+          } catch (err) {
+            settle(() => reject(err instanceof Error ? err : new Error(String(err))))
+            return
+          }
+          text += folded.text
+          usage = addUsage(usage, folded.usage)
+          stdoutBuf = ""
+        }
+        if (ctx.signal.aborted) {
+          settle(() => reject(new AgentInterrupted()))
+          return
+        }
+        if (code !== 0) {
+          const tail = stderr.trim() ? `: ${stderr.trim()}` : ""
+          settle(() => reject(new AgentError({ provider: this.provider, code: "process_exited", message: `${this.provider} exited with code ${code ?? "null"} signal ${signal ?? "null"}${tail}`, retryable: true, usage })))
+          return
+        }
+        const finalText = text.length > 0 ? text : rawStdout.trim()
+        settle(() => resolve({ text: finalText, status: "completed", usage }))
+      })
+    })
+  }
+
+  private consumeLine(line: string, ctx: WorkerContext, forwardProgress: boolean): { text: string; usage: AgentUsage } {
+    const trimmed = line.trim()
+    if (!trimmed) return { text: "", usage: emptyUsage() }
+    try {
+      const event = JSON.parse(trimmed)
+      const error = eventError(event)
+      if (error) throw new AgentError({ provider: this.provider, code: "provider_error", message: error })
+      const folded = foldEvent(event, ctx, forwardProgress)
+      if (isSilentUnknownJson(event, folded)) {
+        return { text: forwardProgress ? "" : trimmed, usage: emptyUsage() }
+      }
+      return folded
+    } catch (err) {
+      if (err instanceof AgentError) throw err
+      const text = line.endsWith("\n") ? line : line + "\n"
+      if (forwardProgress) ctx.onProgress({ kind: "text", text })
+      return { text, usage: emptyUsage() }
+    }
+  }
+
+  private cleanupTurn(child: ChildProcessWithoutNullStreams): void {
+    const cleanup = this.childCleanups.get(child)
+    if (!cleanup) return
+    this.childCleanups.delete(child)
+    runCleanup(cleanup)
+  }
+}
+
+function eventError(value: unknown): string | undefined {
+  if (!isObject(value)) return undefined
+  const type = typeof value.type === "string" ? value.type : typeof value.kind === "string" ? value.kind : undefined
+  if (type !== "error") return undefined
+  if (typeof value.message === "string") return value.message
+  if (typeof value.error === "string") return value.error
+  if (isObject(value.error) && typeof value.error.message === "string") return value.error.message
+  return undefined
+}
+
+function processSpawnError(provider: ProviderId, command: string, err: unknown): AgentError {
+  const code = (err as NodeJS.ErrnoException).code
+  if (code === "ENOENT") {
+    return new AgentError({ provider, code: "binary_not_found", message: `${command} executable was not found`, retryable: false })
+  }
+  if (code === "EACCES") {
+    return new AgentError({ provider, code: "binary_not_executable", message: `${command} executable is not executable`, retryable: false })
+  }
+  return new AgentError({ provider, code: "spawn_failed", message: `failed to spawn ${command}: ${(err as Error).message}`, retryable: true })
+}
+
+function processRuntimeError(provider: ProviderId, command: string, err: NodeJS.ErrnoException): AgentError {
+  if (err.code === "ENOENT") {
+    return new AgentError({ provider, code: "binary_not_found", message: `${command} executable was not found`, retryable: false })
+  }
+  if (err.code === "EACCES") {
+    return new AgentError({ provider, code: "binary_not_executable", message: `${command} executable is not executable`, retryable: false })
+  }
+  return new AgentError({ provider, code: "process_error", message: err.message, retryable: true })
+}
+
+function runCleanup(cleanup: (() => void) | undefined): void {
+  if (!cleanup) return
+  try {
+    cleanup()
+  } catch {
+    // best-effort
+  }
+}
+
+function foldEvent(event: unknown, ctx: WorkerContext, forwardProgress: boolean): { text: string; usage: AgentUsage } {
+  const progress: WorkerProgress[] = []
+  let text = ""
+  let usage = emptyUsage()
+  walk(event, (obj, key) => {
+    const u = usageFromObject(obj, key)
+    if (u) {
+      usage = addUsage(usage, u)
+      progress.push({ kind: "usage", usage: u })
+    }
+    const type = typeof obj.type === "string" ? obj.type : typeof obj.kind === "string" ? obj.kind : ""
+    if ((type === "text" || type === "output_text") && typeof obj.text === "string") {
+      text += obj.text
+      progress.push({ kind: "text", text: obj.text })
+    } else if ((type === "reasoning" || type === "thinking") && typeof (obj.text ?? obj.thinking) === "string") {
+      progress.push({ kind: "reasoning", text: String(obj.text ?? obj.thinking) })
+    } else if (type === "tool_use" && typeof obj.name === "string") {
+      progress.push({ kind: "tool", id: typeof obj.id === "string" ? obj.id : undefined, name: obj.name, input: obj.input })
+    } else if (type === "tool_result") {
+      const output = typeof obj.output === "string" ? obj.output : typeof obj.content === "string" ? obj.content : undefined
+      progress.push({ kind: "tool-result", id: typeof obj.id === "string" ? obj.id : typeof obj.tool_use_id === "string" ? obj.tool_use_id : undefined, output, isError: obj.is_error === true || obj.isError === true })
+    } else if ((type === "message_delta" || type === "agent_end") && typeof obj.text === "string") {
+      text += obj.text
+      progress.push({ kind: "text", text: obj.text })
+    }
+  })
+  if (forwardProgress) {
+    for (const p of progress) ctx.onProgress(p)
+  }
+  return { text, usage }
+}
+
+function isSilentUnknownJson(event: unknown, folded: { text: string; usage: AgentUsage }): boolean {
+  if (folded.text !== "" || folded.usage.inputTokens !== 0 || folded.usage.outputTokens !== 0 || folded.usage.costUsd !== 0) {
+    return false
+  }
+  if (!isObject(event)) return false
+  const type = typeof event.type === "string" ? event.type : typeof event.kind === "string" ? event.kind : undefined
+  if (type) return false
+  return true
+}
+
+function walk(value: unknown, visit: (obj: Record<string, unknown>, key?: string) => void, key?: string): void {
+  if (Array.isArray(value)) {
+    for (const item of value) walk(item, visit, key)
+    return
+  }
+  if (!isObject(value)) return
+  visit(value, key)
+  for (const [childKey, v] of Object.entries(value)) walk(v, visit, childKey)
+}
+
+function usageFromObject(obj: Record<string, unknown>, key?: string): AgentUsage | undefined {
+  const conventionalInput = numberField(obj, "inputTokens") ?? numberField(obj, "input_tokens") ?? numberField(obj, "prompt_tokens")
+  const conventionalOutput = numberField(obj, "outputTokens") ?? numberField(obj, "output_tokens") ?? numberField(obj, "completion_tokens")
+  const piInput = numberField(obj, "input")
+  const piOutput = numberField(obj, "output")
+  const cacheRead = numberField(obj, "cacheRead") ?? numberField(obj, "cache_read")
+  const cacheWrite = numberField(obj, "cacheWrite") ?? numberField(obj, "cache_write")
+  const costObject = isObject(obj.cost) ? obj.cost : undefined
+  const piCost = costObject ? numberField(costObject, "total") : undefined
+  const canUsePiShape = key === "usage" || cacheRead !== undefined || cacheWrite !== undefined || piCost !== undefined
+  const input =
+    conventionalInput ??
+    (canUsePiShape && (piInput !== undefined || cacheRead !== undefined || cacheWrite !== undefined)
+      ? (piInput ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0)
+      : undefined)
+  const output = conventionalOutput ?? (canUsePiShape ? piOutput : undefined)
+  const cost = numberField(obj, "costUsd") ?? numberField(obj, "cost_usd") ?? piCost ?? 0
+  if (input === undefined && output === undefined) return undefined
+  return { inputTokens: input ?? 0, outputTokens: output ?? 0, costUsd: cost }
+}
+
+function numberField(obj: Record<string, unknown>, key: string): number | undefined {
+  const value = obj[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,7 +5,7 @@
 
 import { strict as assert } from "node:assert"
 import { execFileSync, spawn } from "node:child_process"
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { get as httpGet } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -258,8 +258,16 @@ describe("CLI end-to-end (--fake)", () => {
   test("invalid --provider exits 1 with a friendly message, not a stack (M5)", async () => {
     const r = await runCli(["run", wf, "--provider", "claude", "--fake", "--no-serve"], { OMEGACODE_HOME: home })
     assert.equal(r.code, 1)
-    assert.match(r.stderr, /--provider must be one of/)
+    assert.match(r.stderr, /--provider must be one of codex, claude-code, opencode, pi/)
     assert.doesNotMatch(r.stderr, /at \w+ \(/) // no stack frames
+  })
+
+  test("--provider accepts opencode and pi under --fake", async () => {
+    for (const provider of ["opencode", "pi"]) {
+      const r = await runCli(["run", wf, "--provider", provider, "--fake", "--no-serve", "--json"], { OMEGACODE_HOME: home })
+      assert.equal(r.code, 0, `provider=${provider} stderr=${r.stderr}`)
+      assert.equal(JSON.parse(r.stdout).status, "completed")
+    }
   })
 
   test("invalid --sandbox (typo for read-only) is rejected (H14)", async () => {
@@ -613,6 +621,31 @@ describe("CLI misc commands", () => {
     const r = await runCli(["run"])
     assert.equal(r.code, 1)
     assert.match(r.stderr, /usage: omegacode run/)
+  })
+
+  test("doctor checks opencode and pi using provider binary env vars", async () => {
+    const home = mkdtempSync(join(tmpdir(), "omegacode-doctor-"))
+    const writeBin = (name: string, output: string): string => {
+      const bin = join(home, name)
+      writeFileSync(bin, `#!/usr/bin/env node\nconsole.log(${JSON.stringify(output)})\n`)
+      chmodSync(bin, 0o755)
+      return bin
+    }
+
+    try {
+      const r = await runCli(["doctor"], {
+        OMEGACODE_HOME: home,
+        CODEX_BIN: writeBin("codex", "codex 0.0.0-test"),
+        OPENCODE_BIN: writeBin("opencode", "opencode 1.2.3-test"),
+        PI_BIN: writeBin("pi", "pi 4.5.6-test"),
+      })
+      assert.equal(r.code, 0)
+      assert.match(r.stdout, /codex\s+: codex 0\.0\.0-test/)
+      assert.match(r.stdout, /opencode\s+: opencode 1\.2\.3-test/)
+      assert.match(r.stdout, /pi\s+: pi 4\.5\.6-test/)
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })
 

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -7,6 +7,8 @@ import { DefaultWorkerFactory } from "../src/worker/factory.ts"
 import { FakeWorker } from "../src/worker/fake.ts"
 import { ClaudeWorker, bashWriteOutsideCwd, checkTool, isReadOnlyBash, usageFromResult } from "../src/worker/claude.ts"
 import { CodexWorker } from "../src/worker/codex.ts"
+import { OpenCodeWorker } from "../src/worker/opencode.ts"
+import { PiWorker } from "../src/worker/pi.ts"
 import { AgentError, AgentInterrupted, type WorkerContext } from "../src/worker/index.ts"
 import type { AgentSpec, ProviderId } from "../src/dsl/types.ts"
 
@@ -22,6 +24,20 @@ test("returns a ClaudeWorker for 'claude-code'", () => {
   const w = f.get("claude-code")
   assert.ok(w instanceof ClaudeWorker)
   assert.equal(w.id, "claude-code")
+})
+
+test("returns an OpenCodeWorker for 'opencode'", () => {
+  const f = new DefaultWorkerFactory()
+  const w = f.get("opencode")
+  assert.ok(w instanceof OpenCodeWorker)
+  assert.equal(w.id, "opencode")
+})
+
+test("returns a PiWorker for 'pi'", () => {
+  const f = new DefaultWorkerFactory()
+  const w = f.get("pi")
+  assert.ok(w instanceof PiWorker)
+  assert.equal(w.id, "pi")
 })
 
 test("M5: unknown provider id throws instead of silently returning ClaudeWorker", () => {
@@ -41,6 +57,8 @@ test("fake:true routes EVERY provider id to the FakeWorker", () => {
   const f = new DefaultWorkerFactory({ fake: true })
   assert.ok(f.get("codex") instanceof FakeWorker)
   assert.ok(f.get("claude-code") instanceof FakeWorker)
+  assert.ok(f.get("opencode") instanceof FakeWorker)
+  assert.ok(f.get("pi") instanceof FakeWorker)
   // even an otherwise-unknown id is faked (smoke-test convenience)
   assert.ok(f.get("anything" as ProviderId) instanceof FakeWorker)
 })
@@ -49,7 +67,10 @@ test("caches one worker per provider id", () => {
   const f = new DefaultWorkerFactory()
   assert.equal(f.get("codex"), f.get("codex"))
   assert.equal(f.get("claude-code"), f.get("claude-code"))
+  assert.equal(f.get("opencode"), f.get("opencode"))
+  assert.equal(f.get("pi"), f.get("pi"))
   assert.notEqual(f.get("codex") as unknown, f.get("claude-code") as unknown)
+  assert.notEqual(f.get("opencode") as unknown, f.get("pi") as unknown)
 })
 
 test("L5: claudeModel is consumed by the ClaudeWorker", () => {
@@ -72,6 +93,22 @@ test("codexBin is consumed by the CodexWorker", () => {
   const f = new DefaultWorkerFactory({ codexBin: "/opt/codex" })
   const w = f.get("codex")
   assert.ok(w instanceof CodexWorker)
+})
+
+test("opencodeBin is consumed by the OpenCodeWorker", () => {
+  const f = new DefaultWorkerFactory({ opencodeBin: "/opt/opencode" })
+  const w = f.get("opencode") as OpenCodeWorker
+  assert.equal((w as unknown as { opts: { bin?: string } }).opts.bin, "/opt/opencode")
+})
+
+test("pi options are consumed by the PiWorker", () => {
+  const f = new DefaultWorkerFactory({ piBin: "/opt/pi", piProvider: "anthropic", piModel: "m" })
+  const w = f.get("pi") as PiWorker
+  assert.deepEqual((w as unknown as { opts: { bin?: string; provider?: string; model?: string } }).opts, {
+    bin: "/opt/pi",
+    provider: "anthropic",
+    model: "m",
+  })
 })
 
 test("shutdownAll clears the cache and is safe to call repeatedly", async () => {

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -75,6 +75,14 @@ test("keyedSpec captures RESOLVED provider/model so default/CLI overrides invali
   assert.notEqual(k1, k3)
 })
 
+test("keyedSpec distinguishes every provider id", () => {
+  const b = branchKey(ROOT_KEY, "root", 0)
+  const keys = ["codex", "claude-code", "opencode", "pi"].map((provider) =>
+    chainKey(b, 0, "p", keyedSpec({ provider: provider as AgentOpts["provider"], model: "m1" }, undefined)),
+  )
+  assert.equal(new Set(keys).size, keys.length)
+})
+
 test("chainKey depends on branch lineage, local index, prompt and fields", () => {
   const b1 = branchKey(ROOT_KEY, "parallel", 0)
   const b2 = branchKey(ROOT_KEY, "parallel", 1)

--- a/test/opencode-worker.test.ts
+++ b/test/opencode-worker.test.ts
@@ -1,0 +1,176 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import type { SpawnOptions } from "node:child_process"
+import type { AgentSpec } from "../src/dsl/types.js"
+import { OpenCodeWorker } from "../src/worker/opencode.js"
+import { AgentError, AgentInterrupted, type WorkerProgress } from "../src/worker/index.js"
+
+class FakeChild extends EventEmitter {
+  readonly stdin = new EventEmitter() as EventEmitter & { end(value?: string): void }
+  readonly stdout = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  readonly stderr = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  stdinData = ""
+  killed = false
+  constructor() {
+    super()
+    ;(this.stdin as any).end = (value?: string) => {
+      this.stdinData += value ?? ""
+    }
+    ;(this.stdout as any).setEncoding = () => {}
+    ;(this.stderr as any).setEncoding = () => {}
+  }
+  out(value: unknown): void {
+    this.stdout.emit("data", JSON.stringify(value) + "\n")
+  }
+  raw(value: string): void {
+    this.stdout.emit("data", value)
+  }
+  err(value: string): void {
+    this.stderr.emit("data", value)
+  }
+  exit(code = 0): void {
+    this.emit("exit", code, null)
+  }
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+function spec(over: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    prompt: "do it",
+    provider: "opencode",
+    cwd: "/work",
+    sandbox: "danger-full-access",
+    approval: "never",
+    ...over,
+  }
+}
+
+function ctx(signal?: AbortSignal): { signal: AbortSignal; onProgress: (e: WorkerProgress) => void; events: WorkerProgress[] } {
+  const events: WorkerProgress[] = []
+  return { signal: signal ?? new AbortController().signal, onProgress: (e) => events.push(e), events }
+}
+
+test("OpenCodeWorker spawns opencode run with json, dir, model and variant, and sends prompt on stdin", async () => {
+  const calls: Array<{ command: string; args: string[]; options: SpawnOptions }> = []
+  const children: FakeChild[] = []
+  const worker = new OpenCodeWorker({
+    bin: "/bin/opencode",
+    spawnChild: (command, args, options) => {
+      calls.push({ command, args, options })
+      const child = new FakeChild()
+      children.push(child)
+      queueMicrotask(() => {
+        child.out({ type: "text", text: "done" })
+        child.exit()
+      })
+      return child as any
+    },
+  })
+  const result = await worker.runAgent(spec({ model: "anthropic/claude", effort: "high" }), ctx())
+  assert.equal(result.text, "done")
+  assert.equal(calls[0]!.command, "/bin/opencode")
+  assert.deepEqual(calls[0]!.args, ["run", "--format", "json", "--dir", "/work", "--model", "anthropic/claude", "--dangerously-skip-permissions", "--variant", "high"])
+  assert.equal(calls[0]!.options.cwd, "/work")
+  assert.deepEqual(calls[0]!.options.stdio, ["pipe", "pipe", "pipe"])
+  assert.equal(children[0]!.stdinData, "do it")
+})
+
+test("OpenCodeWorker maps JSONL text, reasoning, tools and usage progress", async () => {
+  const child = new FakeChild()
+  const c = ctx()
+  const worker = new OpenCodeWorker({ spawnChild: () => child as any })
+  const p = worker.runAgent(spec(), c)
+  child.out({ type: "reasoning", text: "thinking" })
+  child.out({ type: "tool_use", id: "t1", name: "Read", input: { path: "README.md" } })
+  child.out({ type: "tool_result", tool_use_id: "t1", content: "ok" })
+  child.out({ type: "text", text: "hello" })
+  child.out({ usage: { input_tokens: 3, output_tokens: 4 } })
+  child.exit()
+  const result = await p
+  assert.equal(result.text, "hello")
+  assert.equal(result.usage.inputTokens, 3)
+  assert.equal(result.usage.outputTokens, 4)
+  assert.deepEqual(c.events.map((e) => e.kind), ["reasoning", "tool", "tool-result", "text", "usage"])
+})
+
+test("OpenCodeWorker falls back to plain stdout text", async () => {
+  const child = new FakeChild()
+  const worker = new OpenCodeWorker({ spawnChild: () => child as any })
+  const p = worker.runAgent(spec(), ctx())
+  child.raw("plain answer\n")
+  child.exit()
+  const result = await p
+  assert.equal(result.text, "plain answer\n")
+})
+
+test("OpenCodeWorker structured output runs a silent extraction turn and validates JSON", async () => {
+  const children: FakeChild[] = []
+  const worker = new OpenCodeWorker({
+    spawnChild: () => {
+      const child = new FakeChild()
+      children.push(child)
+      queueMicrotask(() => {
+        if (children.length === 1) {
+          child.out({ type: "text", text: "The count is 7." })
+          child.out({ usage: { input_tokens: 1, output_tokens: 2 } })
+        } else {
+          child.raw('{"count":7}\n')
+          child.out({ usage: { input_tokens: 3, output_tokens: 4 } })
+        }
+        child.exit()
+      })
+      return child as any
+    },
+  })
+  const c = ctx()
+  const result = await worker.runAgent(spec({ schema: { type: "object", properties: { count: { type: "number" } }, required: ["count"] } }), c)
+  assert.deepEqual(result.structured, { count: 7 })
+  assert.equal(result.usage.inputTokens, 4)
+  assert.equal(result.usage.outputTokens, 6)
+  assert.match(children[1]!.stdinData, /JSON Schema/)
+  assert.doesNotMatch(children[1]!.stdinData, /```/)
+  assert.deepEqual(c.events.map((e) => e.kind), ["text", "usage"])
+})
+
+test("OpenCodeWorker rejects unsupported options and malformed model before spawning", async () => {
+  let spawned = 0
+  const worker = new OpenCodeWorker({ spawnChild: () => (spawned++, new FakeChild() as any) })
+  await assert.rejects(worker.runAgent(spec({ sandbox: "read-only" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /supported sandbox values/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ sandbox: "workspace-write" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /cannot enforce sandbox/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ approval: "on-request" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /approval/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ maxTurns: 2 }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /maxTurns/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ model: "claude" }), ctx()), (e) => e instanceof AgentError && e.code === "invalid_model")
+  assert.equal(spawned, 0)
+})
+
+test("OpenCodeWorker nonzero exit includes stderr tail", async () => {
+  const child = new FakeChild()
+  const worker = new OpenCodeWorker({ spawnChild: () => child as any })
+  const p = worker.runAgent(spec(), ctx())
+  child.err("boom\n")
+  child.exit(2)
+  await assert.rejects(p, (e) => e instanceof AgentError && e.code === "process_exited" && /boom/.test(e.message))
+})
+
+test("OpenCodeWorker treats a missing binary as non-retryable", async () => {
+  const worker = new OpenCodeWorker({
+    spawnChild: () => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" })
+    },
+  })
+  await assert.rejects(worker.runAgent(spec(), ctx()), (e) => e instanceof AgentError && e.code === "binary_not_found" && e.retryable === false)
+})
+
+test("OpenCodeWorker abort kills the child and throws AgentInterrupted", async () => {
+  const ac = new AbortController()
+  const child = new FakeChild()
+  const worker = new OpenCodeWorker({ spawnChild: () => child as any })
+  const p = worker.runAgent(spec(), ctx(ac.signal))
+  ac.abort()
+  await assert.rejects(p, (e) => e instanceof AgentInterrupted)
+  assert.equal(child.killed, true)
+})

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -189,6 +189,18 @@ describe("ambient inlined types stay in sync with dsl/types.ts (M31 drift guard)
   })
 })
 
+describe("provider docs stay in sync with dsl/types.ts", () => {
+  const providerIds = [...read("src/dsl/types.ts").match(/export type ProviderId\s*=\s*([^\n]+)/)![1].matchAll(/"([^"]+)"/g)].map((m) => m[1])
+  const docs = `${read("README.md")}\n${read("skill/SKILL.md")}`
+  const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+  for (const provider of providerIds) {
+    test(`documents ${provider}`, () => {
+      assert.match(docs, new RegExp(`(^|[^A-Za-z0-9-])${escapeRegExp(provider)}([^A-Za-z0-9-]|$)`))
+    })
+  }
+})
+
 describe("index.ts exports the public types (M31)", () => {
   const index = read("src/index.ts")
   for (const t of [

--- a/test/pi-worker.test.ts
+++ b/test/pi-worker.test.ts
@@ -1,0 +1,200 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import type { SpawnOptions } from "node:child_process"
+import type { AgentSpec } from "../src/dsl/types.js"
+import { PiWorker } from "../src/worker/pi.js"
+import { AgentError, AgentInterrupted, type WorkerProgress } from "../src/worker/index.js"
+
+class FakeChild extends EventEmitter {
+  readonly stdin = new EventEmitter() as EventEmitter & { end(value?: string): void }
+  readonly stdout = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  readonly stderr = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  stdinData = ""
+  killed = false
+  constructor() {
+    super()
+    ;(this.stdin as any).end = (value?: string) => {
+      this.stdinData += value ?? ""
+    }
+    ;(this.stdout as any).setEncoding = () => {}
+    ;(this.stderr as any).setEncoding = () => {}
+  }
+  out(value: unknown): void {
+    this.stdout.emit("data", JSON.stringify(value) + "\n")
+  }
+  raw(value: string): void {
+    this.stdout.emit("data", value)
+  }
+  err(value: string): void {
+    this.stderr.emit("data", value)
+  }
+  exit(code = 0): void {
+    this.emit("exit", code, null)
+  }
+  kill(): boolean {
+    this.killed = true
+    return true
+  }
+}
+
+function spec(over: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    prompt: "do it",
+    provider: "pi",
+    cwd: "/work",
+    sandbox: "read-only",
+    approval: "never",
+    ...over,
+  }
+}
+
+function ctx(signal?: AbortSignal): { signal: AbortSignal; onProgress: (e: WorkerProgress) => void; events: WorkerProgress[] } {
+  const events: WorkerProgress[] = []
+  return { signal: signal ?? new AbortController().signal, onProgress: (e) => events.push(e), events }
+}
+
+test("PiWorker spawns pi json print command with provider, model, thinking and instructions, and sends prompt on stdin", async () => {
+  const calls: Array<{ command: string; args: string[]; options: SpawnOptions }> = []
+  const children: FakeChild[] = []
+  const worker = new PiWorker({
+    bin: "/bin/pi",
+    provider: "anthropic",
+    model: "default-model",
+    spawnChild: (command, args, options) => {
+      calls.push({ command, args, options })
+      const child = new FakeChild()
+      children.push(child)
+      queueMicrotask(() => {
+        child.out({ type: "text", text: "done" })
+        child.exit()
+      })
+      return child as any
+    },
+  })
+  const result = await worker.runAgent(spec({ model: "override-model", effort: "max", instructions: "be terse" }), ctx())
+  assert.equal(result.text, "done")
+  assert.equal(calls[0]!.command, "/bin/pi")
+  assert.deepEqual(calls[0]!.args.slice(0, 9), [
+    "--mode", "json",
+    "--print",
+    "--no-session",
+    "--no-approve",
+    "--session-dir", calls[0]!.args[6]!,
+    "--tools", "read,grep,find,ls",
+  ])
+  assert.equal(calls[0]!.args.includes("--no-tools"), false)
+  assert.deepEqual(calls[0]!.args.slice(9, 15), ["--provider", "anthropic", "--model", "override-model", "--thinking", "xhigh"])
+  assert.equal(calls[0]!.args[15], "--append-system-prompt")
+  assert.match(calls[0]!.args[16]!, /Target workspace root: \/work/)
+  assert.match(calls[0]!.args[16]!, /be terse/)
+  assert.notEqual(calls[0]!.options.cwd, "/work")
+  assert.match(String(calls[0]!.options.cwd), /omegacode-pi-/)
+  assert.match(String(calls[0]!.options.env?.PI_CODING_AGENT_DIR), /omegacode-pi-/)
+  assert.match(String(calls[0]!.options.env?.PI_CODING_AGENT_SESSION_DIR), /omegacode-pi-/)
+  assert.deepEqual(calls[0]!.options.stdio, ["pipe", "pipe", "pipe"])
+  assert.equal(children[0]!.stdinData, "do it")
+})
+
+test("PiWorker maps JSONL assistant text, thinking and usage progress", async () => {
+  const child = new FakeChild()
+  const c = ctx()
+  const worker = new PiWorker({ spawnChild: () => child as any })
+  const p = worker.runAgent(spec(), c)
+  child.out({ type: "message_delta", content: [{ type: "thinking", thinking: "hmm" }, { type: "text", text: "hello" }] })
+  child.out({ type: "agent_end", usage: { input: 5, output: 6, cacheRead: 2, cacheWrite: 3, cost: { total: 0.12 } } })
+  child.exit()
+  const result = await p
+  assert.equal(result.text, "hello")
+  assert.equal(result.usage.inputTokens, 10)
+  assert.equal(result.usage.outputTokens, 6)
+  assert.equal(result.usage.costUsd, 0.12)
+  assert.deepEqual(c.events.map((e) => e.kind), ["reasoning", "text", "usage"])
+})
+
+test("PiWorker falls back to stdout text and maps none effort to off", async () => {
+  const calls: string[][] = []
+  const worker = new PiWorker({
+    spawnChild: (_command, args) => {
+      calls.push(args)
+      const child = new FakeChild()
+      queueMicrotask(() => {
+        child.raw("plain\n")
+        child.exit()
+      })
+      return child as any
+    },
+  })
+  const result = await worker.runAgent(spec({ effort: "none" }), ctx())
+  assert.equal(result.text, "plain\n")
+  assert.ok(calls[0]!.includes("--thinking"))
+  assert.ok(calls[0]!.includes("off"))
+})
+
+test("PiWorker structured output runs a silent extraction turn and validates JSON", async () => {
+  let turn = 0
+  const worker = new PiWorker({
+    spawnChild: () => {
+      const child = new FakeChild()
+      turn++
+      queueMicrotask(() => {
+        if (turn === 1) {
+          child.out({ type: "text", text: "name: Ada" })
+          child.out({ usage: { input_tokens: 2, output_tokens: 3 } })
+        } else {
+          child.raw('{"name":"Ada"}\n')
+          child.out({ usage: { input_tokens: 4, output_tokens: 5 } })
+        }
+        child.exit()
+      })
+      return child as any
+    },
+  })
+  const result = await worker.runAgent(spec({ schema: { type: "object", properties: { name: { type: "string" } }, required: ["name"] } }), ctx())
+  assert.deepEqual(result.structured, { name: "Ada" })
+  assert.equal(result.usage.inputTokens, 6)
+  assert.equal(result.usage.outputTokens, 8)
+})
+
+test("PiWorker accepts read-only subprocess mode with read/search tools and rejects unsupported options before spawning", async () => {
+  const readOnly = new FakeChild()
+  const workerOk = new PiWorker({ spawnChild: () => readOnly as any })
+  const p = workerOk.runAgent(spec({ sandbox: "read-only" }), ctx())
+  readOnly.out({ type: "text", text: "safe" })
+  readOnly.exit()
+  assert.equal((await p).text, "safe")
+
+  let spawned = 0
+  const worker = new PiWorker({ spawnChild: () => (spawned++, new FakeChild() as any) })
+  await assert.rejects(worker.runAgent(spec({ sandbox: "workspace-write" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /cannot enforce sandbox/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ sandbox: "danger-full-access" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /cannot enforce sandbox/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ approval: "on-request" }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /approval/.test(e.message))
+  await assert.rejects(worker.runAgent(spec({ maxTurns: 2 }), ctx()), (e) => e instanceof AgentError && e.code === "unsupported_option" && /maxTurns/.test(e.message))
+  assert.equal(spawned, 0)
+})
+
+test("PiWorker treats a missing binary as non-retryable", async () => {
+  const worker = new PiWorker({
+    spawnChild: () => {
+      throw Object.assign(new Error("not found"), { code: "ENOENT" })
+    },
+  })
+  await assert.rejects(worker.runAgent(spec(), ctx()), (e) => e instanceof AgentError && e.code === "binary_not_found" && e.retryable === false)
+})
+
+test("PiWorker nonzero exit and abort paths settle correctly", async () => {
+  const failed = new FakeChild()
+  const worker1 = new PiWorker({ spawnChild: () => failed as any })
+  const p1 = worker1.runAgent(spec(), ctx())
+  failed.err("bad\n")
+  failed.exit(1)
+  await assert.rejects(p1, (e) => e instanceof AgentError && e.code === "process_exited" && /bad/.test(e.message))
+
+  const ac = new AbortController()
+  const aborted = new FakeChild()
+  const worker2 = new PiWorker({ spawnChild: () => aborted as any })
+  const p2 = worker2.runAgent(spec(), ctx(ac.signal))
+  ac.abort()
+  await assert.rejects(p2, (e) => e instanceof AgentInterrupted)
+  assert.equal(aborted.killed, true)
+})

--- a/test/primitives.test.ts
+++ b/test/primitives.test.ts
@@ -618,18 +618,19 @@ test("random() varies with the run seed but is stable for the same seed", async 
   assert.notEqual(await run(7), await run(8)) // run-distinct
 })
 
-test("H14: agent() rejects invalid sandbox/effort/approval values at spec resolution", async () => {
+test("H14: agent() rejects invalid provider/sandbox/effort/approval values at spec resolution", async () => {
   // Workflow bodies are untyped JS: an unvalidated `sandbox: "readonly"` (typo for "read-only")
   // falls off the worker policy switches and is treated as writable — read-only silently bypassed.
   const b = build()
   try {
+    await assert.rejects(runBody(b, `return await agent("x", { provider: "open-code" })`), /invalid provider "open-code"/)
     await assert.rejects(runBody(b, `return await agent("x", { sandbox: "readonly" })`), /invalid sandbox "readonly"/)
     await assert.rejects(runBody(b, `return await agent("x", { effort: "ultra" })`), /invalid effort "ultra"/)
     await assert.rejects(runBody(b, `return await agent("x", { approval: "always" })`), /invalid approval "always"/)
     // the worker never saw an unvalidated policy
     assert.equal(b.worker.calls.length, 0)
     // valid values still resolve and run
-    const ok = await runBody(b, `return await agent("y", { sandbox: "read-only", effort: "high", approval: "never" })`)
+    const ok = await runBody(b, `return await agent("y", { provider: "opencode", sandbox: "read-only", effort: "high", approval: "never" })`)
     assert.equal(ok, "echo:y")
   } finally {
     b.cleanup()

--- a/test/provider-env.test.ts
+++ b/test/provider-env.test.ts
@@ -1,0 +1,81 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { runWorkflow } from "../src/runtime/run.ts"
+
+test("PI_PROVIDER and PI_MODEL env vars are forwarded to pi when no per-agent model is set", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "omega-pi-env-"))
+  const prevHome = process.env.OMEGACODE_HOME
+  const prevBin = process.env.PI_BIN
+  const prevProvider = process.env.PI_PROVIDER
+  const prevModel = process.env.PI_MODEL
+  const prevRecord = process.env.RECORD
+  const repoCwd = process.cwd()
+  try {
+    const record = join(dir, "record.json")
+    const bin = join(dir, "pi-fake.cjs")
+    writeFileSync(
+      bin,
+      [
+        "#!/usr/bin/env node",
+        'const fs = require("node:fs");',
+        "let stdin = '';",
+        'process.stdin.setEncoding("utf8");',
+        "process.stdin.on('data', (chunk) => { stdin += chunk; });",
+        "process.stdin.on('end', () => {",
+        "  fs.writeFileSync(process.env.RECORD, JSON.stringify({ argv: process.argv.slice(2), stdin, cwd: process.cwd(), agentDir: process.env.PI_CODING_AGENT_DIR, sessionDir: process.env.PI_CODING_AGENT_SESSION_DIR }));",
+        '  console.log(JSON.stringify({ type: "text", text: "ok" }));',
+        "});",
+      ].join("\n"),
+    )
+    chmodSync(bin, 0o755)
+
+    const wf = join(dir, "pi-env.workflow.js")
+    writeFileSync(
+      wf,
+      [
+        'export const meta = { name: "pi-env-test", description: "env wiring", defaultProvider: "pi" }',
+        'return await agent("hello from workflow")',
+      ].join("\n"),
+    )
+
+    process.env.OMEGACODE_HOME = join(dir, "home")
+    process.env.PI_BIN = bin
+    process.env.PI_PROVIDER = "anthropic"
+    process.env.PI_MODEL = "claude-test"
+    process.env.RECORD = record
+
+    const outcome = await runWorkflow({ file: wf, quiet: true })
+    assert.equal(outcome.status, "completed")
+    const launch = JSON.parse(readFileSync(record, "utf8")) as { argv: string[]; stdin: string; cwd: string; agentDir: string; sessionDir: string }
+    assert.deepEqual(launch.argv.slice(0, 9), [
+      "--mode", "json",
+      "--print",
+      "--no-session",
+      "--no-approve",
+      "--session-dir", launch.argv[6]!,
+      "--tools", "read,grep,find,ls",
+    ])
+    assert.equal(launch.argv.includes("--no-tools"), false)
+    assert.deepEqual(launch.argv.slice(9, 13), ["--provider", "anthropic", "--model", "claude-test"])
+    assert.notEqual(launch.cwd, repoCwd)
+    assert.match(launch.cwd, /omegacode-pi-/)
+    assert.match(launch.agentDir, /omegacode-pi-/)
+    assert.match(launch.sessionDir, /omegacode-pi-/)
+    assert.equal(launch.stdin, "hello from workflow")
+  } finally {
+    restoreEnv("OMEGACODE_HOME", prevHome)
+    restoreEnv("PI_BIN", prevBin)
+    restoreEnv("PI_PROVIDER", prevProvider)
+    restoreEnv("PI_MODEL", prevModel)
+    restoreEnv("RECORD", prevRecord)
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}

--- a/test/resume.test.ts
+++ b/test/resume.test.ts
@@ -506,6 +506,18 @@ return await agent("one")`,
   })
 })
 
+test("H14: an invalid meta.defaultProvider fails the run at startup", async () => {
+  await withHome(async (home) => {
+    const file = join(home, "wf.js")
+    writeFileSync(
+      file,
+      `export const meta = { name: "t", description: "d", defaultProvider: "open-code" }
+return await agent("one")`,
+    )
+    await assert.rejects(runFile(file), /invalid provider "open-code"/)
+  })
+})
+
 test("rec #4: a v1 journal (meta WITHOUT keyVersion) is rejected on resume", async () => {
   await withHome(async (home) => {
     const file = join(home, "wf.js")

--- a/test/subprocess-jsonl.test.ts
+++ b/test/subprocess-jsonl.test.ts
@@ -1,0 +1,181 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import type { AgentSpec } from "../src/dsl/types.js"
+import { AgentError, AgentInterrupted, type WorkerProgress } from "../src/worker/index.js"
+import { SubprocessJsonlWorker } from "../src/worker/subprocess-jsonl.js"
+
+class FakeChild extends EventEmitter {
+  readonly stdin = new EventEmitter() as EventEmitter & { end(value?: string): void }
+  readonly stdout = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  readonly stderr = new EventEmitter() as EventEmitter & { setEncoding(e: string): void }
+  killed: Array<string | undefined> = []
+  constructor() {
+    super()
+    ;(this.stdin as any).end = () => {}
+    ;(this.stdout as any).setEncoding = () => {}
+    ;(this.stderr as any).setEncoding = () => {}
+  }
+  out(value: unknown): void {
+    this.stdout.emit("data", JSON.stringify(value) + "\n")
+  }
+  raw(value: string): void {
+    this.stdout.emit("data", value)
+  }
+  err(value: string): void {
+    this.stderr.emit("data", value)
+  }
+  exit(code = 0): void {
+    this.emit("exit", code, null)
+  }
+  kill(signal?: string): boolean {
+    this.killed.push(signal)
+    return true
+  }
+}
+
+function spec(over: Partial<AgentSpec> = {}): AgentSpec {
+  return {
+    prompt: "do it",
+    provider: "opencode",
+    cwd: "/work",
+    sandbox: "read-only",
+    approval: "never",
+    ...over,
+  }
+}
+
+function ctx(signal?: AbortSignal): { signal: AbortSignal; onProgress: (e: WorkerProgress) => void; events: WorkerProgress[] } {
+  const events: WorkerProgress[] = []
+  return { signal: signal ?? new AbortController().signal, onProgress: (e) => events.push(e), events }
+}
+
+test("SubprocessJsonlWorker buffers JSONL events split across stdout chunks", async () => {
+  const child = new FakeChild()
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => child as any,
+    buildTurn: (s, prompt) => ({ command: "tool", args: [], cwd: s.cwd, stdin: prompt }),
+  })
+  const resultPromise = worker.runSubprocessAgent(spec(), ctx())
+  child.raw('{"type":"text","text":"hel')
+  child.raw('lo"}\n')
+  child.exit()
+  assert.equal((await resultPromise).text, "hello")
+})
+
+test("SubprocessJsonlWorker treats explicit error events as fatal provider errors", async () => {
+  const child = new FakeChild()
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => child as any,
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  const resultPromise = worker.runSubprocessAgent(spec(), ctx())
+  child.out({ type: "error", message: "fatal" })
+  await assert.rejects(resultPromise, (e) => e instanceof AgentError && e.code === "provider_error" && /fatal/.test(e.message))
+  assert.deepEqual(child.killed, [undefined])
+})
+
+test("SubprocessJsonlWorker keeps recoverable tool_result error fields non-fatal", async () => {
+  const child = new FakeChild()
+  const c = ctx()
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => child as any,
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  const resultPromise = worker.runSubprocessAgent(spec(), c)
+  child.out({ type: "tool_result", id: "t1", error: "command failed", is_error: true })
+  child.out({ type: "text", text: "recovered" })
+  child.exit()
+  assert.equal((await resultPromise).text, "recovered")
+  assert.equal(c.events.some((event) => event.kind === "tool-result" && event.isError === true), true)
+})
+
+test("SubprocessJsonlWorker short-circuits an already-aborted signal before spawning", async () => {
+  const ac = new AbortController()
+  ac.abort()
+  let spawned = 0
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => (spawned++, new FakeChild() as any),
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  await assert.rejects(worker.runSubprocessAgent(spec(), ctx(ac.signal)), (e) => e instanceof AgentInterrupted)
+  assert.equal(spawned, 0)
+})
+
+test("SubprocessJsonlWorker classifies EACCES spawn failures as non-retryable", async () => {
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => {
+      throw Object.assign(new Error("permission denied"), { code: "EACCES" })
+    },
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  await assert.rejects(worker.runSubprocessAgent(spec(), ctx()), (e) => e instanceof AgentError && e.code === "binary_not_executable" && e.retryable === false)
+})
+
+test("SubprocessJsonlWorker reports invalid structured extraction JSON with both turns' usage", async () => {
+  let turn = 0
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => {
+      turn++
+      const child = new FakeChild()
+      queueMicrotask(() => {
+        if (turn === 1) {
+          child.out({ type: "text", text: "count is seven" })
+          child.out({ usage: { input_tokens: 1, output_tokens: 2 } })
+        } else {
+          child.raw("not json\n")
+          child.out({ usage: { input_tokens: 3, output_tokens: 4 } })
+        }
+        child.exit()
+      })
+      return child as any
+    },
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  await assert.rejects(
+    worker.runSubprocessAgent(spec({ schema: { type: "object", properties: { count: { type: "number" } }, required: ["count"] } }), ctx()),
+    (e) => e instanceof AgentError && e.code === "invalid_structured_output" && e.usage?.inputTokens === 4 && e.usage.outputTokens === 6,
+  )
+})
+
+test("SubprocessJsonlWorker truncates stderr tails on nonzero exit", async () => {
+  const child = new FakeChild()
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => child as any,
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd }),
+  })
+  const resultPromise = worker.runSubprocessAgent(spec(), ctx())
+  child.err(`start-${"x".repeat(20_000)}-tail`)
+  child.exit(2)
+  await assert.rejects(resultPromise, (e) => e instanceof AgentError && /-tail/.test(e.message) && !/start-/.test(e.message))
+})
+
+test("SubprocessJsonlWorker runs per-turn cleanup after exit", async () => {
+  const child = new FakeChild()
+  let cleaned = 0
+  const worker = new SubprocessJsonlWorker({
+    provider: "opencode",
+    allowedSandboxes: ["read-only"],
+    spawnChild: () => child as any,
+    buildTurn: (s) => ({ command: "tool", args: [], cwd: s.cwd, cleanup: () => cleaned++ }),
+  })
+  const resultPromise = worker.runSubprocessAgent(spec(), ctx())
+  child.out({ type: "text", text: "ok" })
+  child.exit()
+  assert.equal((await resultPromise).text, "ok")
+  assert.equal(cleaned, 1)
+})


### PR DESCRIPTION
## Summary

Adds OpenCode and Pi as omegacode providers alongside Codex and Claude Code.

- Extends provider typing, CLI validation, runtime defaults, factory wiring, resume/key coverage, and ambient declarations for `opencode` and `pi`.
- Adds subprocess JSONL worker support shared by the new providers, including structured-output extraction, usage folding, cleanup, abort handling, and spawn error classification.
- Adds `OpenCodeWorker` using `opencode run --format json` with `provider/model` model names and `danger-full-access` only, because OpenCode permissions are not a security sandbox.
- Adds `PiWorker` using `pi --mode json --print` with read-only read/search tools, isolated state dirs, `PI_PROVIDER` / `PI_MODEL` defaults, and Pi model pass-through.
- Updates `omegacode doctor`, README, and the omegacode skill docs, plus adds tests to keep provider docs in sync.

## Validation

- `npm run typecheck`
- `node --test --import tsx --test-timeout=30000 test/opencode-worker.test.ts test/pi-worker.test.ts test/provider-env.test.ts test/subprocess-jsonl.test.ts test/cli.test.ts test/packaging.test.ts`
- `node --test --import tsx --test-timeout=30000 ./test/*.test.ts`

Full suite result locally: 525 passing, 2 skipped.