### PR TITLE
fix(claude): recover finished agents from background-task stream shapes

### DIFF
--- a/src/worker/claude.ts
+++ b/src/worker/claude.ts
@@ -10,7 +10,7 @@ import { readlinkSync, realpathSync } from "node:fs"
 import { homedir } from "node:os"
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { query, type Options, type PermissionResult, type SDKMessage } from "@anthropic-ai/claude-agent-sdk"
-import { emptyUsage, type AgentResult, type AgentSpec, type AgentUsage, type Effort, type Sandbox } from "../dsl/types.js"
+import { addUsage, emptyUsage, type AgentResult, type AgentSpec, type AgentUsage, type Effort, type Sandbox } from "../dsl/types.js"
 import type { Worker, WorkerContext } from "./index.js"
 import { AgentError, AgentInterrupted } from "./index.js"
 import { assertValidSchema, toClaudeOutputFormat } from "./schema.js"
@@ -97,23 +97,62 @@ export class ClaudeWorker implements Worker {
     if (this.opts.pathToClaudeCodeExecutable) options.pathToClaudeCodeExecutable = this.opts.pathToClaudeCodeExecutable
 
     try {
-      let last: SDKMessage | undefined
+      // The CLI normally ends the stream with a `result` message carrying the final text, usage,
+      // and structured output. When background tasks (Monitor / Bash run_in_background) straddle
+      // the end of the turn, that contract breaks two ways: the stream can end with no result
+      // message at all, or a task-notification turn appended after the real answer can emit its
+      // own result that lacks the structured output an earlier turn already provided (and whose
+      // text is watcher chatter, not the answer). So: prefer the last NON-notification result
+      // (`origin.kind` discriminates), and capture the accepted StructuredOutput tool payload
+      // from the stream as the recovery source — otherwise finished agents get marked failed.
+      let primaryResult: Extract<SDKMessage, { type: "result" }> | undefined
+      let anyResult: Extract<SDKMessage, { type: "result" }> | undefined
+      let lastText = ""
+      let structuredFromTool: unknown
+      let pendingStructuredId: string | undefined
+      let pendingStructuredInput: unknown
+      let lastUsageId: string | undefined
+      let streamUsage = emptyUsage()
       const runQuery = this.opts.queryFn ?? query
       for await (const message of runQuery({ prompt: spec.prompt, options })) {
-        last = message
-        if (message.type === "assistant") {
-          for (const block of asBlocks((message.message as { content?: unknown }).content)) {
+        if (message.type === "result") {
+          anyResult = message
+          if (message.origin?.kind !== "task-notification") primaryResult = message
+        } else if (message.type === "assistant") {
+          const m = message.message as { id?: unknown; usage?: unknown; content?: unknown }
+          // Subagent (Task) messages relay through the same stream with parent_tool_use_id set —
+          // keep them out of the recovery bookkeeping (progress events still flow below).
+          const topLevel = message.parent_tool_use_id == null
+          // Best-effort usage for the no-result recovery path (a result message supersedes this).
+          // The SDK repeats one API message across consecutive assistant events with the same
+          // (final) usage, so count each id once; cost stays 0 — only a result message knows it.
+          if (topLevel && typeof m.id === "string" && m.id !== lastUsageId) {
+            lastUsageId = m.id
+            streamUsage = addUsage(streamUsage, usageFromResult({ usage: m.usage }))
+          }
+          for (const block of asBlocks(m.content)) {
             if (block.type === "text" && typeof block.text === "string") {
+              if (topLevel) lastText = block.text
               ctx.onProgress({ kind: "text", text: block.text })
             } else if (block.type === "thinking" && typeof block.thinking === "string") {
               ctx.onProgress({ kind: "reasoning", text: block.thinking })
             } else if (block.type === "tool_use" && typeof block.name === "string") {
+              if (topLevel && block.name === "StructuredOutput" && typeof block.id === "string") {
+                pendingStructuredId = block.id
+                pendingStructuredInput = block.input
+              }
               ctx.onProgress({ kind: "tool", id: typeof block.id === "string" ? block.id : undefined, name: block.name, input: block.input })
             }
           }
         } else if (message.type === "user") {
           for (const block of asBlocks((message.message as { content?: unknown }).content)) {
             if (block.type === "tool_result") {
+              // Commit the payload only once the CLI accepted it — a rejected call gets retried
+              // by the model and must not shadow the eventual good one.
+              if (pendingStructuredId !== undefined && block.tool_use_id === pendingStructuredId && block.is_error !== true) {
+                structuredFromTool = pendingStructuredInput
+                pendingStructuredId = pendingStructuredInput = undefined
+              }
               const out = typeof block.content === "string" ? block.content : JSON.stringify(block.content)
               ctx.onProgress({ kind: "tool-result", id: typeof block.tool_use_id === "string" ? block.tool_use_id : undefined, output: out, isError: block.is_error === true })
             }
@@ -121,19 +160,37 @@ export class ClaudeWorker implements Worker {
         }
       }
 
-      if (!last || last.type !== "result") {
+      if (!primaryResult && spec.schema && structuredFromTool !== undefined && pendingStructuredId === undefined) {
+        // The real turn's result never arrived (at most a notification turn's did), but the agent
+        // demonstrably finished its deliverable — the CLI accepted its StructuredOutput call.
+        // Recover instead of discarding finished work; schema validation still happens downstream
+        // in finalizeResult. A still-pending call is evidence of the opposite — the agent was
+        // superseding the accepted payload when the stream cut — so it disables recovery rather
+        // than deliver stale data. An abort can truncate the stream into this same shape — that
+        // must stay an interruption, not a success with a possibly-superseded payload.
+        if (ctx.signal.aborted) throw new AgentInterrupted()
+        // Tokens come from the stream; cost only a result message knows — take what we have.
+        if (anyResult) streamUsage.costUsd = usageFromResult(anyResult).costUsd
+        return { text: lastText, structured: structuredFromTool, status: "completed", usage: streamUsage }
+      }
+      // A lone notification-turn result is still a better last resort than no_result for
+      // free-form agents; with a schema the recovery branch above already outranked it.
+      const lastResult = primaryResult ?? anyResult
+      if (!lastResult) {
+        // Free-form agents have no completion marker (partial text from a truncated stream must
+        // not pass as an answer), so without the StructuredOutput evidence the error stays hard.
         throw new AgentError({ provider: "claude-code", code: "no_result", message: "claude query ended without a result" })
       }
-      const usage = usageFromResult(last)
-      if (last.subtype !== "success") {
+      const usage = usageFromResult(lastResult)
+      if (lastResult.subtype !== "success") {
         // error_max_turns is a terminal cap, not a transient fault — never retry it. Carry the
         // usage on the error: failed turns still bill, so budget ceilings must see them.
-        const retryable = last.subtype !== "error_max_turns" && /rate|overload|529|429/i.test(last.subtype)
-        throw new AgentError({ provider: "claude-code", code: last.subtype, message: `claude result: ${last.subtype}`, retryable, usage })
+        const retryable = lastResult.subtype !== "error_max_turns" && /rate|overload|529|429/i.test(lastResult.subtype)
+        throw new AgentError({ provider: "claude-code", code: lastResult.subtype, message: `claude result: ${lastResult.subtype}`, retryable, usage })
       }
       return {
-        text: last.result,
-        structured: spec.schema ? last.structured_output : undefined,
+        text: lastResult.result,
+        structured: spec.schema ? (lastResult.structured_output ?? structuredFromTool) : undefined,
         status: "completed",
         usage,
       }

--- a/test/claude-worker.test.ts
+++ b/test/claude-worker.test.ts
@@ -52,6 +52,8 @@ function spec(over: Partial<AgentSpec> = {}): AgentSpec {
   return { prompt: "do the thing", provider: "claude-code", cwd: "/work/repo", sandbox: "workspace-write", approval: "never", ...over }
 }
 
+const SCHEMA = { type: "object", properties: { answer: { type: "number" } }, required: ["answer"] }
+
 /** The shape the worker installs (the SDK type carries an extra options param we don't use). */
 type Gate = (toolName: string, input: Record<string, unknown>) => Promise<PermissionResult>
 
@@ -131,11 +133,10 @@ test("spec → SDK options: cwd/model/maxTurns/effort floor/instructions preset 
 })
 
 test("schema spec: outputFormat is sent and structured_output comes back on the result", async () => {
-  const schema = { type: "object", properties: { answer: { type: "number" } }, required: ["answer"] }
   const calls: QueryCall[] = []
   const worker = new ClaudeWorker({ queryFn: scripted([resultMsg({ structured_output: { answer: 42 } })], calls) })
-  const res = await worker.runAgent(spec({ schema }), ctx())
-  assert.deepEqual(calls[0]!.options.outputFormat, { type: "json_schema", schema })
+  const res = await worker.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.deepEqual(calls[0]!.options.outputFormat, { type: "json_schema", schema: SCHEMA })
   assert.deepEqual(res.structured, { answer: 42 })
   // without a schema the same SDK field is ignored and no outputFormat is sent
   const calls2: QueryCall[] = []
@@ -253,6 +254,179 @@ test("an SDK throw is wrapped as retryable sdk_error (message preserved)", async
     },
   })
   await assert.rejects(syncThrow.runAgent(spec(), ctx()), (e) => e instanceof AgentError && e.code === "sdk_error" && /spawn failed/.test(e.message))
+})
+
+// ===========================================================================
+// background-task stream shapes — StructuredOutput recovery
+// (Claude Code's background tasks can end the stream without a result message,
+// or append a post-answer task-notification turn whose result lacks
+// structured_output and whose text is watcher chatter.)
+// ===========================================================================
+
+/** assistant StructuredOutput call + its accepted tool_result. */
+function structuredOutputTurn(payload: unknown, over: { id?: string; is_error?: boolean } = {}): unknown[] {
+  const id = over.id ?? "so1"
+  return [
+    assistantMsg([{ type: "tool_use", id, name: "StructuredOutput", input: payload }]),
+    userMsg([{ type: "tool_result", tool_use_id: id, content: "Structured output provided successfully", is_error: over.is_error ?? false }]),
+  ]
+}
+
+test("stream ends with NO result after an accepted StructuredOutput → recovered, not no_result", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      ...structuredOutputTurn({ answer: 42 }),
+      assistantMsg([{ type: "text", text: "gate is green" }]), // final answer, then the stream just closes
+    ]),
+  })
+  const res = await worker.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.equal(res.status, "completed")
+  assert.deepEqual(res.structured, { answer: 42 })
+  assert.equal(res.text, "gate is green")
+})
+
+test("no-result recovery sums assistant usage deduped by API message id (cost unknowable → 0)", async () => {
+  const usage = { input_tokens: 100, cache_read_input_tokens: 1000, cache_creation_input_tokens: 10, output_tokens: 7 }
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      { type: "assistant", message: { id: "m1", usage, content: [{ type: "tool_use", id: "so1", name: "StructuredOutput", input: { answer: 1 } }] } },
+      { type: "assistant", message: { id: "m1", usage, content: [{ type: "text", text: "same API message, second block" }] } }, // repeat id: counted once
+      userMsg([{ type: "tool_result", tool_use_id: "so1", content: "ok", is_error: false }]),
+      { type: "assistant", message: { id: "m2", usage: { input_tokens: 50, output_tokens: 3 }, content: [{ type: "text", text: "done" }] } },
+    ]),
+  })
+  const res = await worker.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.equal(res.usage.inputTokens, 1160)
+  assert.equal(res.usage.outputTokens, 10)
+  assert.equal(res.usage.costUsd, 0)
+})
+
+test("a post-answer NOTIFICATION turn's result lacking structured_output → recovered from the tool payload", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      ...structuredOutputTurn({ answer: 42 }),
+      assistantMsg([{ type: "text", text: "that's just the watcher exiting — nothing new" }]),
+      resultMsg({ origin: { kind: "task-notification" }, total_cost_usd: 1.68 }), // no structured_output field
+    ]),
+  })
+  const res = await worker.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.deepEqual(res.structured, { answer: 42 })
+  assert.equal(res.usage.costUsd, 1.68) // cost still taken from the notification result — it's all we have
+})
+
+test("a non-success NOTIFICATION result after an accepted StructuredOutput does not fail the finished agent", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      ...structuredOutputTurn({ answer: 42 }),
+      resultMsg({ subtype: "error_during_execution", origin: { kind: "task-notification" } }),
+    ]),
+  })
+  const res = await worker.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.equal(res.status, "completed")
+  assert.deepEqual(res.structured, { answer: 42 })
+})
+
+test("the PRIMARY turn's result is preferred over a later notification turn's (text and structured)", async () => {
+  // free-form: the real answer must not be replaced by watcher chatter
+  const freeForm = new ClaudeWorker({
+    queryFn: scripted([
+      resultMsg({ result: "the real analysis" }),
+      resultMsg({ result: "background task completed — nothing new", origin: { kind: "task-notification" } }),
+    ]),
+  })
+  const r1 = await freeForm.runAgent(spec(), ctx())
+  assert.equal(r1.text, "the real analysis")
+  // schema: the primary result's structured_output survives a notification result that lacks it
+  const schemaed = new ClaudeWorker({
+    queryFn: scripted([
+      resultMsg({ structured_output: { answer: 7 } }),
+      resultMsg({ origin: { kind: "task-notification" } }),
+    ]),
+  })
+  const r2 = await schemaed.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.deepEqual(r2.structured, { answer: 7 })
+})
+
+test("when the result carries structured_output (even alongside a tool payload), the result's wins; null falls back", async () => {
+  const carried = new ClaudeWorker({
+    queryFn: scripted([...structuredOutputTurn({ answer: 1 }), resultMsg({ structured_output: { answer: 2 } })]),
+  })
+  assert.deepEqual((await carried.runAgent(spec({ schema: SCHEMA }), ctx())).structured, { answer: 2 })
+  // an explicit null structured_output must not shadow the accepted tool payload
+  const nulled = new ClaudeWorker({
+    queryFn: scripted([...structuredOutputTurn({ answer: 3 }), resultMsg({ structured_output: null })]),
+  })
+  assert.deepEqual((await nulled.runAgent(spec({ schema: SCHEMA }), ctx())).structured, { answer: 3 })
+})
+
+test("a result followed by trailing assistant messages still resolves (last RESULT, not last message)", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([resultMsg(), assistantMsg([{ type: "text", text: "trailing notification chatter" }])]),
+  })
+  const res = await worker.runAgent(spec(), ctx())
+  assert.equal(res.status, "completed")
+  assert.equal(res.text, "all done")
+})
+
+test("abort that truncates the stream after an accepted StructuredOutput → AgentInterrupted, not completed", async () => {
+  const ac = new AbortController()
+  const worker = new ClaudeWorker({
+    queryFn: () =>
+      (async function* (): AsyncGenerator<SDKMessage> {
+        for (const m of structuredOutputTurn({ answer: 42 })) yield m as SDKMessage
+        ac.abort() // the SDK can end the iterator cleanly on abort — no throw, no result message
+      })(),
+  })
+  await assert.rejects(worker.runAgent(spec({ schema: SCHEMA }), ctx(ac.signal)), (e) => e instanceof AgentInterrupted)
+})
+
+test("subagent-relayed messages (parent_tool_use_id set) do not feed recovery state or usage", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      {
+        type: "assistant",
+        parent_tool_use_id: "task1", // a Task subagent's stream relayed through the parent query
+        message: { id: "sub1", usage: { input_tokens: 999, output_tokens: 99 }, content: [{ type: "tool_use", id: "so1", name: "StructuredOutput", input: { answer: 13 } }] },
+      },
+      userMsg([{ type: "tool_result", tool_use_id: "so1", content: "ok", is_error: false }]),
+    ]),
+  })
+  await assert.rejects(worker.runAgent(spec({ schema: SCHEMA }), ctx()), (e) => e instanceof AgentError && e.code === "no_result")
+})
+
+test("a REJECTED StructuredOutput call is not recovery evidence; a later accepted one is", async () => {
+  // rejected only → still no_result
+  const rejectedOnly = new ClaudeWorker({
+    queryFn: scripted([...structuredOutputTurn({ answer: "bad" }, { is_error: true }), assistantMsg([{ type: "text", text: "hm" }])]),
+  })
+  await assert.rejects(rejectedOnly.runAgent(spec({ schema: SCHEMA }), ctx()), (e) => e instanceof AgentError && e.code === "no_result")
+  // rejected then accepted retry → the retry's payload is recovered
+  const retried = new ClaudeWorker({
+    queryFn: scripted([
+      ...structuredOutputTurn({ answer: "bad" }, { id: "so1", is_error: true }),
+      ...structuredOutputTurn({ answer: 7 }, { id: "so2" }),
+    ]),
+  })
+  const res = await retried.runAgent(spec({ schema: SCHEMA }), ctx())
+  assert.deepEqual(res.structured, { answer: 7 })
+})
+
+test("an IN-FLIGHT StructuredOutput call at truncation disables recovery (the accepted payload was being superseded)", async () => {
+  const worker = new ClaudeWorker({
+    queryFn: scripted([
+      ...structuredOutputTurn({ answer: 1 }), // accepted
+      assistantMsg([{ type: "tool_use", id: "so2", name: "StructuredOutput", input: { answer: 2 } }]), // stream cuts before so2's tool_result
+    ]),
+  })
+  await assert.rejects(worker.runAgent(spec({ schema: SCHEMA }), ctx()), (e) => e instanceof AgentError && e.code === "no_result")
+})
+
+test("no-result recovery is schema-gated: free-form agents keep the hard no_result error", async () => {
+  // Same truncated-stream shape, but no spec.schema → partial text must not pass as an answer.
+  const worker = new ClaudeWorker({
+    queryFn: scripted([...structuredOutputTurn({ answer: 42 }), assistantMsg([{ type: "text", text: "partial" }])]),
+  })
+  await assert.rejects(worker.runAgent(spec(), ctx()), (e) => e instanceof AgentError && e.code === "no_result")
 })
 
 // ===========================================================================


### PR DESCRIPTION
## Problem

Claude Code background tasks (Monitor / `Bash run_in_background`) can break the SDK `query()` result contract two ways:

1. The stream ends with **no `result` message at all** → worker threw `no_result`.
2. A post-answer **task-notification turn** appends its own result that lacks the `structured_output` an earlier turn already provided → `agent({schema}) returned no structured output`.

Both marked demonstrably finished agents as failed. Observed in run `wf_7dcef2b93566`: 4 agents completed their gates (1282/1288 green), called `StructuredOutput` successfully ("Structured output provided successfully" in the transcript), and were discarded — roughly an hour of green suite runs lost to retries, journaled at 0 tokens / $0.

## Fix

- **Origin-aware result selection**: prefer the last result whose `origin.kind !== 'task-notification'` over blind last-result-wins. Also fixes a latent free-form bug where a watcher turn's chatter ("nothing new") could replace the agent's real answer text.
- **StructuredOutput recovery**: capture the last *accepted* `StructuredOutput` tool payload from the stream; when no primary result arrives, complete with it (schema validation still runs downstream in `finalizeResult`). A still-pending call at truncation disables recovery — the payload was being superseded. An aborted stream stays `AgentInterrupted`, not a phantom success.
- **Null-safe fallback**: `structured_output ?? capturedPayload` so an explicit `null` doesn't shadow the accepted payload.
- **Usage accounting**: recovered runs report stream-derived usage (shared `addUsage`/`usageFromResult`, deduped by API message id, subagent `parent_tool_use_id` messages excluded) instead of 0 tokens / $0, so `--budget` ceilings see the spend.

Free-form (no-schema) agents intentionally keep the hard `no_result` error on a truly result-less stream — there is no completion marker equivalent to an accepted `StructuredOutput`, and truncated text must not pass as an answer.

The underlying CLI/SDK behavior (no result message when background tasks straddle end-of-turn) remains an upstream issue; this makes omegacode robust to it.

## Testing

- 11 new tests in `test/claude-worker.test.ts` scripting the exact stream shapes via the `queryFn` seam: no-result recovery, notification-turn shadowing (text + structured), non-success notification result, null `structured_output`, rejected-then-retried and in-flight-superseded `StructuredOutput`, abort-during-truncation, subagent filtering, usage dedup.
- Full suite: 560/560 pass, `tsc --noEmit` clean.
- Multi-angle review (7 finders + adversarial verification, including against the SDK's `sdk.d.ts` types and the CLI's StructuredOutput implementation) folded back into the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)